### PR TITLE
Correctly pass in amount into StripeCheckout

### DIFF
--- a/app/assets/javascripts/payola/checkout_button.js
+++ b/app/assets/javascripts/payola/checkout_button.js
@@ -10,7 +10,7 @@ var Payola = {
             handler.open({
                 name: options.name,
                 description: options.description,
-                amount: options.amount,
+                amount: options.price,
                 panelLabel: options.panel_label,
                 allowRememberMe: options.allow_remember_me,
                 zipCode: options.verify_zip_code,


### PR DESCRIPTION
Right now Stripe Checkout ends up with `amount` parameter as empty because it's actually named `price` in our scheme.
