### PR TITLE
pass through currency to checkout button

### DIFF
--- a/app/assets/javascripts/payola/checkout_button.js
+++ b/app/assets/javascripts/payola/checkout_button.js
@@ -14,6 +14,7 @@ var PayolaCheckout = {
                 panelLabel: options.panel_label,
                 allowRememberMe: options.allow_remember_me,
                 zipCode: options.verify_zip_code,
+                currency: options.currency,
                 email: options.email || undefined
             });
             e.preventDefault();

--- a/app/models/concerns/payola/sellable.rb
+++ b/app/models/concerns/payola/sellable.rb
@@ -17,6 +17,10 @@ module Payola
       self.class.product_class
     end
 
+    def currency
+      'usd'
+    end
+
     module ClassMethods
       def sellable?
         true

--- a/app/services/payola/create_sale.rb
+++ b/app/services/payola/create_sale.rb
@@ -10,7 +10,7 @@ module Payola
         s.email = params[:stripeEmail]
         s.stripe_token = params[:stripeToken]
         s.affiliate_id = affiliate.try(:id)
-        s.currency = product.respond_to?(:currency) ? product.currency : 'usd'
+        s.currency = product.currency
         s.signed_custom_fields = params[:signed_custom_fields]
 
         if coupon

--- a/app/views/payola/transactions/_checkout.html.erb
+++ b/app/views/payola/transactions/_checkout.html.erb
@@ -49,6 +49,7 @@
     price: <%= sellable.price %>,
     name: "<%= name %>",
     description: "<%= description %>",
+    currency: "<%= sellable.currency %>",
     product_image_path: "<%= product_image_path %>",
     publishable_key: "<%= Payola.publishable_key_for_sale(sale) %>",
     panel_label: "<%= panel_label %>",


### PR DESCRIPTION
Currently the pay button always shows USD, even if the sellable changes it to e.g. GBP

I've changed it so the currency is passed through to handler.open, which will update the {{amount}} text in the pay button

see https://stripe.com/docs/checkout#integration-options-currency

![screen shot 2014-10-28 at 09 15 05](https://cloud.githubusercontent.com/assets/2088870/4805914/116b4990-5e83-11e4-987b-4ca9be6749ea.png)
