### PR TITLE
Add setup fees for subscriptions

### DIFF
--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -11,6 +11,7 @@ module Payola
         s.affiliate_id = affiliate.try(:id)
         s.currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
         s.coupon = params[:coupon]
+        s.setup_fee = params[:setup_fee]
         #s.signed_custom_fields = params[:signed_custom_fields]
 
         s.amount = plan.amount

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -13,6 +13,7 @@ module Payola
           plan:  subscription.plan.stripe_id,
         }
         create_params[:coupon] = subscription.coupon if subscription.coupon.present?
+        create_params[:account_balance] = subscription.setup_fee if subscription.setup_fee.present?
 
         customer = Stripe::Customer.create(create_params, secret_key)
 
@@ -38,4 +39,3 @@ module Payola
 
   end
 end
-

--- a/db/migrate/20141122020755_add_setup_fee_to_payola_subscriptions.rb
+++ b/db/migrate/20141122020755_add_setup_fee_to_payola_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddSetupFeeToPayolaSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :payola_subscriptions, :setup_fee, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141120170744) do
+ActiveRecord::Schema.define(version: 20141122020755) do
 
   create_table "owners", force: true do |t|
     t.datetime "created_at"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 20141120170744) do
     t.text     "signed_custom_fields"
     t.text     "customer_address"
     t.text     "business_address"
+    t.integer  "setup_fee"
   end
 
   add_index "payola_subscriptions", ["guid"], name: "index_payola_subscriptions_on_guid"


### PR DESCRIPTION
I need a way to charge a one-time set up fee for subscriptions.

[There are two ways to do this](https://support.stripe.com/questions/metered-subscription-billing):
- Set an `account_balance` on the customer at the same time as setting a plan.
- Create an invoice before setting the plan (for itemization on the invoice, would require a name for the charge).

This PR just implements the first. Like coupons, it just passes the setup_fee directly to Stripe (as account_balance).

Thoughts?
