### PR TITLE
Stripe plan callback fix

### DIFF
--- a/app/models/concerns/payola/plan.rb
+++ b/app/models/concerns/payola/plan.rb
@@ -12,7 +12,7 @@ module Payola
 
       validates_uniqueness_of :stripe_id
 
-      before_save :create_stripe_plan, on: :create
+      before_create :create_stripe_plan
 
       has_many :subscriptions, :class_name => "Payola::Subscription"
 

--- a/spec/concerns/plan_spec.rb
+++ b/spec/concerns/plan_spec.rb
@@ -34,5 +34,14 @@ module Payola
       subscription_plan.save!
     end
 
+    it "should not try to create the plan at stripe before the model is updated" do
+      subscription_plan = build(:subscription_plan)
+      subscription_plan.save!
+      subscription_plan.name = "new name"
+
+      Payola::CreatePlan.should_not_receive(:call)
+      subscription_plan.save!
+    end
+
   end
 end


### PR DESCRIPTION
The callback to create the plan at stripe should only happen when the plan is first created, not when it is updated.
