### PR TITLE
Don't require callers to #call the keys

### DIFF
--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -36,11 +36,11 @@ module Payola
     end
 
     def secret_key_for_sale(sale)
-      return secret_key_retriever.call(sale)
+      return secret_key_retriever.call(sale).to_s
     end
 
     def publishable_key_for_sale(sale)
-      return publishable_key_retriever.call(sale)
+      return publishable_key_retriever.call(sale).to_s
     end
 
     def subscribe(name, callable = Proc.new)

--- a/spec/payola_spec.rb
+++ b/spec/payola_spec.rb
@@ -13,13 +13,13 @@ module Payola
     it "should set publishable key from env" do
       ENV['STRIPE_PUBLISHABLE_KEY'] = 'some_key'
       Payola.reset!
-      expect(Payola.publishable_key.call).to eq 'some_key'
+      expect(Payola.publishable_key).to eq 'some_key'
     end
 
     it "should set secret key from env" do
       ENV['STRIPE_SECRET_KEY'] = 'some_secret'
       Payola.reset!
-      expect(Payola.secret_key.call).to eq 'some_secret'
+      expect(Payola.secret_key).to eq 'some_secret'
     end
   end
 


### PR DESCRIPTION
e739e16 introduced a regression where the Payola user has to `#call`
the result of the public and private keys. This commit instead wraps
the env in a wrapper object that properly evaluates `to_s` and `==`.

Fixes #71