### PR TITLE
Fix subscriptions with setup fees.

### DIFF
--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -62,12 +62,12 @@ module Payola
       if subscription.setup_fee.present?
         plan = subscription.plan
         description = plan.try(:setup_fee_description, subscription) || 'Setup Fee'
-        Stripe::InvoiceItem.create(
+        Stripe::InvoiceItem.create({
           customer: customer.id,
           amount: subscription.setup_fee,
           currency: subscription.currency,
           description: description
-        )
+        }, secret_key)
       end
 
       customer


### PR DESCRIPTION
This fixes an issue where subscriptions would fail if they had a setup fee, due to the missing secret_key.

Because of this issue, #71, and #73, we should probably cut a 1.2.4 gem. At least for me, the published 1.2.3 is pretty much unusable.