### PR TITLE
Fix error handling for subscriptions.

### DIFF
--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -52,18 +52,22 @@ var PayolaOnestepSubscriptionForm = {
         var handler = function(data) {
             if (data.status === "active") {
                 window.location = base_path + '/confirm_subscription/' + guid;
-            } else if (data.status === "errored") {
-                PayolaOnestepSubscriptionForm.showError(form, data.error);
             } else {
                 setTimeout(function() { PayolaOnestepSubscriptionForm.poll(form, num_retries_left - 1, guid, base_path); }, 500);
             }
         };
+        var errorHandler = function(jqXHR){
+          if(jqXHR.responseJSON.status === "errored"){
+            PayolaSubscriptionForm.showError(form, jqXHR.responseJSON.error);
+          }
+        };
 
         $.ajax({
             type: 'GET',
+            dataType: 'json',
             url: base_path + '/subscription_status/' + guid,
             success: handler,
-            error: handler
+            error: errorHandler
         });
     },
 

--- a/app/assets/javascripts/payola/subscription_form_twostep.js
+++ b/app/assets/javascripts/payola/subscription_form_twostep.js
@@ -51,18 +51,22 @@ var PayolaSubscriptionForm = {
                 form.append($('<input type="hidden" name="payola_subscription_guid"></input>').val(guid));
                 form.append(PayolaSubscriptionForm.authenticityTokenInput());
                 form.get(0).submit();
-            } else if (data.status === "errored") {
-                PayolaSubscriptionForm.showError(form, data.error);
             } else {
                 setTimeout(function() { PayolaSubscriptionForm.poll(form, num_retries_left - 1, guid, base_path); }, 500);
             }
         };
+        var errorHandler = function(jqXHR){
+          if(jqXHR.responseJSON.status === "errored"){
+            PayolaSubscriptionForm.showError(form, jqXHR.responseJSON.error);
+          }
+        };
 
         $.ajax({
             type: 'GET',
+            dataType: 'json',
             url: base_path + '/subscription_status/' + guid,
             success: handler,
-            error: handler
+            error: errorHandler
         });
     },
 


### PR DESCRIPTION
The `error` function for `$.ajax` just receives a `jqXHR` object
instead of parsed data. We return an error code in cases where the
card has been declined, which triggers the error handler instead of
the success handler. So we need a dedicated error handler instead
of trying to overload the success handler to handle all the cases.