### PR TITLE
Skip Stripe token fetch when already present

### DIFF
--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -33,9 +33,12 @@ var PayolaOnestepSubscriptionForm = {
         if (response.error) {
             PayolaOnestepSubscriptionForm.showError(form, response.error.message);
         } else {
-            var email = form.find("[data-payola='email']").val();
-            var coupon = form.find("[data-payola='coupon']").val();
-            var quantity = form.find("[data-payola='quantity']").val();
+            form.find("[data-stripe='number'], [data-stripe='cvc'], [data-stripe='exp_month']").prop('disabled', true);
+            form.find("[data-stripe='exp_year'], [data-payola='first_name'], [data-payola='last_name']").prop('disabled', true);
+
+            var email = form.find("[data-payola='email']").prop('disabled', true).val();
+            var coupon = form.find("[data-payola='coupon']").prop('disabled', true).val();
+            var quantity = form.find("[data-payola='quantity']").prop('disabled', true).val();
 
             var base_path = form.data('payola-base-path');
             var plan_type = form.data('payola-plan-type');

--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -21,6 +21,7 @@ var PayolaOnestepSubscriptionForm = {
     submitForm: function(form){
       $.ajax({
             type: 'POST',
+            dataType: 'json',
             url: $(form).attr('action'),
             data: form.serialize(),
             success: function(data) { PayolaOnestepSubscriptionForm.poll(form, 60, data.guid, base_path); },

--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -19,7 +19,8 @@ var PayolaOnestepSubscriptionForm = {
     },
 
     submitForm: function(form){
-      $.ajax({
+        var base_path = form.data('payola-base-path');
+        $.ajax({
             type: 'POST',
             dataType: 'json',
             url: $(form).attr('action'),
@@ -40,7 +41,6 @@ var PayolaOnestepSubscriptionForm = {
             var coupon = form.find("[data-payola='coupon']").prop('disabled', true).val();
             var quantity = form.find("[data-payola='quantity']").prop('disabled', true).val();
 
-            var base_path = form.data('payola-base-path');
             var plan_type = form.data('payola-plan-type');
             var plan_id = form.data('payola-plan-id');
 

--- a/app/models/concerns/payola/plan.rb
+++ b/app/models/concerns/payola/plan.rb
@@ -41,7 +41,7 @@ module Payola
       end
 
       def plan_class
-        self.to_s.underscore
+        self.to_s.parameterize
       end
     end
 


### PR DESCRIPTION
If applied, this PR will skip a second token fetch to Stripe on form re-submits (i.e. when the application server responds with an error and the user resubmits the form).