### PR TITLE
Support for namespaced models

### DIFF
--- a/app/models/concerns/payola/plan.rb
+++ b/app/models/concerns/payola/plan.rb
@@ -41,7 +41,7 @@ module Payola
       end
 
       def plan_class
-        self.to_s.underscore
+        self.to_s.underscore.parameterize
       end
     end
 


### PR DESCRIPTION
Namespaced models resolve to invalid classes :
Some::Model.to_s.underscore => some/model :-1: 
Some::Model.to_s.underscore. parameterize => some-model :+1: 