### PR TITLE
Support API version 2015-02-18

### DIFF
--- a/app/services/payola/charge_card.rb
+++ b/app/services/payola/charge_card.rb
@@ -26,7 +26,7 @@ module Payola
         Stripe::Customer.retrieve(sale.stripe_customer_id, secret_key)
       else
         Stripe::Customer.create({
-          card: sale.stripe_token,
+          source: sale.stripe_token,
           email: sale.email
         }, secret_key)
       end
@@ -54,9 +54,9 @@ module Payola
       sale.update_attributes(
         stripe_id:          charge.id,
         stripe_customer_id: customer.id,
-        card_last4:         charge.card.last4,
-        card_expiration:    Date.new(charge.card.exp_year, charge.card.exp_month, 1),
-        card_type:          charge.card.respond_to?(:brand) ? charge.card.brand : charge.card.type,
+        card_last4:         charge.source.last4,
+        card_expiration:    Date.new(charge.source.exp_year, charge.source.exp_month, 1),
+        card_type:          charge.source.brand,
         fee_amount:         fee
       )
     end

--- a/app/services/payola/invoice_behavior.rb
+++ b/app/services/payola/invoice_behavior.rb
@@ -39,8 +39,8 @@ module Payola
 
       def update_sale_with_charge(sale, charge)
         sale.stripe_id  = charge.id
-        sale.card_type  = charge.card.respond_to?(:brand) ? charge.card.brand : charge.card.type
-        sale.card_last4 = charge.card.last4
+        sale.card_type  = charge.source.brand
+        sale.card_last4 = charge.source.last4
 
         if charge.respond_to?(:fee)
           sale.fee_amount = charge.fee

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -27,7 +27,7 @@ module Payola
         create_params[:coupon] = subscription.coupon if subscription.coupon.present?
         stripe_sub = customer.subscriptions.create(create_params)
 
-        card = customer.cards.data.first
+        card = customer.sources.data.first
         subscription.update_attributes(
           stripe_id:             stripe_sub.id,
           stripe_customer_id:    customer.id,
@@ -62,8 +62,8 @@ module Payola
         return Stripe::Customer.retrieve(customer_id, secret_key)
       else
         customer_create_params = {
-          card:  subscription.stripe_token,
-          email: subscription.email
+          source: subscription.stripe_token,
+          email:  subscription.email
         }
   
         customer = Stripe::Customer.create(customer_create_params, secret_key)

--- a/app/services/payola/update_card.rb
+++ b/app/services/payola/update_card.rb
@@ -5,11 +5,11 @@ module Payola
       begin
         customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
 
-        customer.card = token
+        customer.source = token
         customer.save
 
         customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
-        card = customer.cards.retrieve(customer.default_card, secret_key)
+        card = customer.sources.retrieve(customer.default_source, secret_key)
 
         subscription.update_attributes(
           card_type: card.brand,

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -72,6 +72,7 @@ module Payola
 
     def reset!
       StripeEvent.event_retriever = Retriever
+      Stripe.api_version = ENV['STRIPE_API_VERSION'] || '2015-02-18'
 
       self.background_worker = nil
       self.event_filter = lambda { |event| event }

--- a/payola.gemspec
+++ b/payola.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.1"
   s.add_dependency "jquery-rails"
-  s.add_dependency "stripe", ">= 1.16.0"
+  s.add_dependency "stripe", ">= 1.20.1"
   s.add_dependency "aasm", ">= 4.0.7"
   s.add_dependency "stripe_event", ">= 1.3.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency 'factory_girl_rails'
-  s.add_development_dependency "stripe-ruby-mock", "~> 2.0"
+  s.add_development_dependency "stripe-ruby-mock", "~> 2.1.0"
   s.add_development_dependency "sucker_punch", "~> 1.2.1"
   s.add_development_dependency "docverter"
 

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -30,7 +30,7 @@ module Payola
       it "should sync timestamps" do
         plan = create(:subscription_plan)
         subscription = build(:subscription, plan: plan)
-        stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, card: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
+        stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
         old_start = subscription.current_period_start
         old_end = subscription.current_period_end
         trial_start = subscription.trial_start
@@ -53,7 +53,7 @@ module Payola
       it "should sync non-timestamp fields" do
         plan = create(:subscription_plan)
         subscription = build(:subscription, plan: plan)
-        stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, card: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
+        stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
 
         expect(stripe_sub).to receive(:quantity).and_return(10).at_least(1)
         expect(stripe_sub).to receive(:cancel_at_period_end).and_return(true).at_least(1)

--- a/spec/services/payola/invoice_failed_spec.rb
+++ b/spec/services/payola/invoice_failed_spec.rb
@@ -8,7 +8,7 @@ module Payola
 
       customer = Stripe::Customer.create(
         email: 'foo',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         plan: plan.stripe_id
       )
 

--- a/spec/services/payola/invoice_paid_spec.rb
+++ b/spec/services/payola/invoice_paid_spec.rb
@@ -9,7 +9,7 @@ module Payola
 
       customer = Stripe::Customer.create(
         email: 'foo',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         plan: plan.stripe_id
       )
 
@@ -28,7 +28,7 @@ module Payola
       plan = create(:subscription_plan)
       customer = Stripe::Customer.create(
         email: 'foo',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         plan: plan.stripe_id
       )
 


### PR DESCRIPTION
Note that this *forces* API version 2015-02-18. If you have non-Payola
code using the Stripe gem you will have to update it.

Fixes #93
Fixes #96