### PR TITLE
Ensure the Stripe::Customer hasn't been deleted

### DIFF
--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -70,13 +70,6 @@ module Payola
 
       customer = Stripe::Customer.create(customer_create_params, secret_key)
 
-      customer_create_params = {
-        card:  subscription.stripe_token,
-        email: subscription.email
-      }
-
-      customer = Stripe::Customer.create(customer_create_params, secret_key)
-
       if subscription.setup_fee.present?
         plan = subscription.plan
         description = plan.try(:setup_fee_description, subscription) || 'Setup Fee'

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -59,8 +59,10 @@ module Payola
       if subs && subs.length >= 1
         first_sub = subs.first
         customer_id = first_sub.stripe_customer_id
-        customer = Stripe::Customer.retrieve(customer_id, secret_key)
-        return customer unless customer.try(:deleted)
+        unless customer_id.blank?
+          customer = Stripe::Customer.retrieve(customer_id, secret_key)
+          return customer unless customer.try(:deleted)
+        end
       end
 
       customer_create_params = {

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -66,8 +66,8 @@ module Payola
       end
 
       customer_create_params = {
-        card:  subscription.stripe_token,
-        email: subscription.email
+        source: subscription.stripe_token,
+        email:  subscription.email
       }
 
       customer = Stripe::Customer.create(customer_create_params, secret_key)


### PR DESCRIPTION
If a customer has been deleted within Stripe for some reason, attempting to access any attributes (other than `id` or `deleted`) with throw an exception.