### PR TITLE
Allow custom URL to be used with the subscription checkout button

### DIFF
--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -44,7 +44,7 @@ var PayolaSubscriptionCheckout = {
         $(".payola-subscription-checkout-button-spinner").show();
         $.ajax({
             type: "POST",
-            url: options.base_path + "/subscribe/" + options.plan_class + "/" + options.plan_id,
+            url: form.attr('action'),
             data: form.serialize(),
             success: function(data) { PayolaSubscriptionCheckout.poll(data.guid, 60, options); },
             error: function(data) { PayolaSubscriptionCheckout.showError(data.responseJSON.error, options); }

--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -16,11 +16,12 @@
   custom_fields = local_assigns.fetch :custom_fields, nil
   billing_address = local_assigns.fetch :billing_address, false
   shipping_address = local_assigns.fetch :shipping_address, false
+  form_url = local_assigns.fetch :form_url, payola.subscribe_path(plan_class: plan_class, plan_id: plan_id)
 
   sale = Payola::Subscription.new(plan: plan)
 
   button_id = "payola-button-#{plan_class}-#{plan_id}"
-  
+
   form_id = "#{button_id}-form"
 
   currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
@@ -67,7 +68,7 @@
 <script src="https://checkout.stripe.com/checkout.js"></script>
 <link rel="stylesheet" href="https://checkout.stripe.com/v3/checkout/button.css"></link>
 
-<%= form_tag payola.subscribe_path(plan_class: plan_class, plan_id: plan_id), html_hash do %>
+<%= form_tag form_url, html_hash do %>
   <button class="<%= button_class %> payola-subscription-checkout-button" id="<%= button_id %>">
     <span class="payola-subscription-checkout-button-text" style="display: block; <%= button_inner_style %>"><%= button_text %></span>
     <span class="payola-subscription-checkout-button-spinner" style="display: none; <%= button_inner_style %>">Please wait...</span>


### PR DESCRIPTION
Similar to when creating a custom form, allow the checkout button flow to accept (and respect) a custom URL to post data to after async Stripe communication has finished