### PR TITLE
Cancel subscription button

### DIFF
--- a/app/views/payola/subscriptions/_cancel.html.erb
+++ b/app/views/payola/subscriptions/_cancel.html.erb
@@ -6,5 +6,5 @@
 %>
 
 <%= form_tag payola.cancel_subscription_path(subscription.guid), :method => :delete do %>
-  <%= submit_tag button_text, html: { disabled: disabled, class: button_class }, data: { confirm: confirm_text } %>
+  <%= submit_tag button_text, disabled: disabled, class: button_class, data: { confirm: confirm_text } %>
 <% end %>

--- a/app/views/payola/subscriptions/_cancel.html.erb
+++ b/app/views/payola/subscriptions/_cancel.html.erb
@@ -2,7 +2,7 @@
   button_class = local_assigns.fetch :button_class, 'stripe-button-el'
   button_text = local_assigns.fetch :button_text, "Cancel Subscription"
   confirm_text = local_assigns.fetch :confirm_text, "Are you sure?"
-  disabled = subscription.active?
+  disabled = !subscription.active?
   url = local_assigns.fetch :url, payola.cancel_subscription_path(subscription.guid)
 %>
 

--- a/app/views/payola/subscriptions/_cancel.html.erb
+++ b/app/views/payola/subscriptions/_cancel.html.erb
@@ -1,5 +1,6 @@
 <%
   button_class = local_assigns.fetch :button_class, 'stripe-button-el'
+  button_id = local_assigns.fetch :button_id, "cancel-subscription-#{subscription.guid}"
   button_text = local_assigns.fetch :button_text, "Cancel Subscription"
   confirm_text = local_assigns.fetch :confirm_text, "Are you sure?"
   disabled = !subscription.active?
@@ -7,5 +8,7 @@
 %>
 
 <%= form_tag url, :method => :delete do %>
-  <%= submit_tag button_text, disabled: disabled, class: button_class, data: { confirm: confirm_text } %>
-<% end %>
+  <%= button_tag type: 'submit', class: button_class, disabled: disabled, data: { confirm: confirm_text } do %>
+    <%= content_tag(:span, button_text, class: 'payola-subscription-cancel-buton-text') %>
+  <% end -%>
+<% end -%>

--- a/app/views/payola/subscriptions/_cancel.html.erb
+++ b/app/views/payola/subscriptions/_cancel.html.erb
@@ -3,8 +3,9 @@
   button_text = local_assigns.fetch :button_text, "Cancel Subscription"
   confirm_text = local_assigns.fetch :confirm_text, "Are you sure?"
   disabled = subscription.active?
+  url = local_assigns.fetch :url, payola.cancel_subscription_path(subscription.guid)
 %>
 
-<%= form_tag payola.cancel_subscription_path(subscription.guid), :method => :delete do %>
+<%= form_tag url, :method => :delete do %>
   <%= submit_tag button_text, disabled: disabled, class: button_class, data: { confirm: confirm_text } %>
 <% end %>


### PR DESCRIPTION
* Fix a bug where the `class` and `disabled` attributes weren't being properly set on the cancel subscription submit tag
* Allow a custom url to be passed to the cancel subscription partial via a `url` local.
* Render cancel subscription button the with the same HTML structure as the checkout button