### PR TITLE
Mysql utf8 indices

### DIFF
--- a/db/migrate/20141001170138_create_payola_sales.rb
+++ b/db/migrate/20141001170138_create_payola_sales.rb
@@ -2,9 +2,9 @@ class CreatePayolaSales < ActiveRecord::Migration
   def change
     create_table :payola_sales do |t|
       t.string   "email"
-      t.string   "guid"
+      t.string   "guid",          limit: 191
       t.integer  "product_id"
-      t.string   "product_type"
+      t.string   "product_type",  limit: 191
       t.datetime "created_at"
       t.datetime "updated_at"
       t.string   "state"

--- a/db/migrate/20141001170138_create_payola_sales.rb
+++ b/db/migrate/20141001170138_create_payola_sales.rb
@@ -4,7 +4,7 @@ class CreatePayolaSales < ActiveRecord::Migration
       t.string   "email"
       t.string   "guid",          limit: 191
       t.integer  "product_id"
-      t.string   "product_type",  limit: 191
+      t.string   "product_type",  limit: 100
       t.datetime "created_at"
       t.datetime "updated_at"
       t.string   "state"

--- a/db/migrate/20141001170138_create_payola_sales.rb
+++ b/db/migrate/20141001170138_create_payola_sales.rb
@@ -1,7 +1,7 @@
 class CreatePayolaSales < ActiveRecord::Migration
   def change
     create_table :payola_sales do |t|
-      t.string   "email"
+      t.string   "email",         limit: 191
       t.string   "guid",          limit: 191
       t.integer  "product_id"
       t.string   "product_type",  limit: 100

--- a/db/migrate/20141002203725_add_stripe_customer_id_to_sale.rb
+++ b/db/migrate/20141002203725_add_stripe_customer_id_to_sale.rb
@@ -1,6 +1,6 @@
 class AddStripeCustomerIdToSale < ActiveRecord::Migration
   def change
-    add_column :payola_sales, :stripe_customer_id, :string
+    add_column :payola_sales, :stripe_customer_id, :string, limit: 191
     add_index :payola_sales, :stripe_customer_id
   end
 end

--- a/db/migrate/20141029135848_add_owner_to_payola_sale.rb
+++ b/db/migrate/20141029135848_add_owner_to_payola_sale.rb
@@ -1,7 +1,7 @@
 class AddOwnerToPayolaSale < ActiveRecord::Migration
   def change
     add_column :payola_sales, :owner_id, :integer
-    add_column :payola_sales, :owner_type, :string
+    add_column :payola_sales, :owner_type, :string, limit: 100
 
     add_index :payola_sales, [:owner_id, :owner_type]
   end

--- a/db/migrate/20141107025420_add_guid_to_payola_subscriptions.rb
+++ b/db/migrate/20141107025420_add_guid_to_payola_subscriptions.rb
@@ -1,6 +1,6 @@
 class AddGuidToPayolaSubscriptions < ActiveRecord::Migration
   def change
-    add_column :payola_subscriptions, :guid, :string
+    add_column :payola_subscriptions, :guid, :string, limit: 191
     add_index :payola_subscriptions, :guid
   end
 end

--- a/spec/services/payola/change_subscription_quantity_spec.rb
+++ b/spec/services/payola/change_subscription_quantity_spec.rb
@@ -9,7 +9,7 @@ module Payola
         @plan = create(:subscription_plan)
 
         token = StripeMock.generate_card_token({})
-        @subscription = create(:subscription, quantity: 1, stripe_token: token)
+        @subscription = create(:subscription, quantity: 1, stripe_token: token, plan: @plan)
         StartSubscription.call(@subscription)
         Payola::ChangeSubscriptionQuantity.call(@subscription, 2)
       end


### PR DESCRIPTION
mysql `utf8mb4` encoding (4 byte UTF-8) supports a max index length of `767` bytes. This means that a string column that will have an index has two options:
  * limit the max length of the column to `191` chars (`191 * 4 = 764`)
  * use a prefix index (index only the first part of the string), and ensure the number of bytes indexes is less than the max

In this PR, I've opted to take the first approach. I thought about checking the encoding on the database connection, and only limiting the length of the columns if it was set to `utf8mb4`, but I figured that could potentially just cause issues if only one database limited the column lengths.

While testing this change, I also fixed a spec that was failing when running using mysql.