### PR TITLE
Lock stripe-ruby-mock to avoid build errors.

### DIFF
--- a/payola.gemspec
+++ b/payola.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency 'factory_girl_rails'
-  s.add_development_dependency "stripe-ruby-mock", "~> 2.1.0"
+  s.add_development_dependency "stripe-ruby-mock", "2.1.0"
   s.add_development_dependency "sucker_punch", "~> 1.2.1"
   s.add_development_dependency "docverter"
 


### PR DESCRIPTION
It looks like version 2.1.1 causes a few tests to break due to API differences. This commit gets the build working in the short term. I'm going to look at the actual build failures in a different branch.
