### PR TITLE
`Stripe::Charge` requires `amount` and `currency`

### DIFF
--- a/spec/factories/sales.rb
+++ b/spec/factories/sales.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     product
     stripe_token 'tok_test'
     currency 'usd'
+    amount 100
   end
 end

--- a/spec/services/payola/invoice_failed_spec.rb
+++ b/spec/services/payola/invoice_failed_spec.rb
@@ -14,7 +14,7 @@ module Payola
 
       sub = create(:subscription, plan: plan, stripe_customer_id: customer.id, stripe_id: customer.subscriptions.first.id)
 
-      charge = Stripe::Charge.create(failure_message: 'Failed! OMG!')
+      charge = Stripe::Charge.create(amount: 100, currency: 'usd', failure_message: 'Failed! OMG!')
       event = StripeMock.mock_webhook_event('invoice.payment_failed', subscription: sub.stripe_id, charge: charge.id)
 
       count = Payola::Sale.count

--- a/spec/services/payola/invoice_paid_spec.rb
+++ b/spec/services/payola/invoice_paid_spec.rb
@@ -34,7 +34,7 @@ module Payola
 
       sub = create(:subscription, plan: plan, stripe_customer_id: customer.id, stripe_id: customer.subscriptions.first.id)
 
-      charge = Stripe::Charge.create
+      charge = Stripe::Charge.create(amount: 100, currency: 'usd')
       event = StripeMock.mock_webhook_event('invoice.payment_succeeded', subscription: sub.stripe_id, charge: charge.id)
 
       count = Payola::Sale.count


### PR DESCRIPTION
As of rebelidealist/stripe-ruby-mock@cff9ac40f4, which is part of version 2.1.1, these attributes are now required when creating a `Charge` object.

This pull request may supersede #118 if it's an acceptable fix.
