### PR TITLE
Fix payment failed when card is declined.

### DIFF
--- a/app/services/payola/invoice_behavior.rb
+++ b/app/services/payola/invoice_behavior.rb
@@ -44,7 +44,7 @@ module Payola
 
         if charge.respond_to?(:fee)
           sale.fee_amount = charge.fee
-        else
+        elsif !charge.balance_transaction.nil?
           balance = Stripe::BalanceTransaction.retrieve(charge.balance_transaction, secret_key)
           sale.fee_amount = balance.fee
         end


### PR DESCRIPTION
This occurred when the card was accepted, but was declined when the charge was made using card 4000000000000341