### PR TITLE
Added bitcoin option to checkout.js

### DIFF
--- a/app/assets/javascripts/payola/checkout_button.js
+++ b/app/assets/javascripts/payola/checkout_button.js
@@ -24,7 +24,6 @@ var PayolaCheckout = {
             shippingAddress: options.shipping_address,
             currency: options.currency,
             bitcoin: options.bitcoin,
-            capture: options.capture,
             email: options.email || undefined
         });
 

--- a/app/assets/javascripts/payola/checkout_button.js
+++ b/app/assets/javascripts/payola/checkout_button.js
@@ -23,6 +23,8 @@ var PayolaCheckout = {
             billingAddress: options.billing_address,
             shippingAddress: options.shipping_address,
             currency: options.currency,
+            bitcoin: options.bitcoin,
+            capture: options.capture,
             email: options.email || undefined
         });
 

--- a/app/views/payola/transactions/_checkout.html.erb
+++ b/app/views/payola/transactions/_checkout.html.erb
@@ -16,7 +16,6 @@
   billing_address = local_assigns.fetch :billing_address, false
   shipping_address = local_assigns.fetch :shipping_address, false
   bitcoin = local_assigns.fetch :bitcoin, false
-  capture = local_assigns.fetch :capture, true
 
   sale = Payola::Sale.new(product: sellable)
 

--- a/app/views/payola/transactions/_checkout.html.erb
+++ b/app/views/payola/transactions/_checkout.html.erb
@@ -15,6 +15,8 @@
   custom_fields = local_assigns.fetch :custom_fields, nil
   billing_address = local_assigns.fetch :billing_address, false
   shipping_address = local_assigns.fetch :shipping_address, false
+  bitcoin = local_assigns.fetch :bitcoin, false
+  capture = local_assigns.fetch :capture, true
 
   sale = Payola::Sale.new(product: sellable)
 
@@ -50,7 +52,9 @@
     email: email,
     verify_zip_code: verify_zip_code,
     billing_address: billing_address,
-    shipping_address: shipping_address
+    shipping_address: shipping_address,
+    bitcoin: bitcoin,
+    capture: capture,
   }
 
   raw_data[:signed_custom_fields] = sale.verifier.generate(custom_fields) if custom_fields

--- a/app/views/payola/transactions/_checkout.html.erb
+++ b/app/views/payola/transactions/_checkout.html.erb
@@ -52,8 +52,7 @@
     verify_zip_code: verify_zip_code,
     billing_address: billing_address,
     shipping_address: shipping_address,
-    bitcoin: bitcoin,
-    capture: capture,
+    bitcoin: bitcoin
   }
 
   raw_data[:signed_custom_fields] = sale.verifier.generate(custom_fields) if custom_fields


### PR DESCRIPTION
Added bitcoin option to checkout.js. Won't work unless the amount is USD. Stripe will show the bitcoin option greyed out when the currency is different from USD.

Related to issue #124 still checking about allowing two-step payments.