### PR TITLE
Support for canceling subscription at period end

### DIFF
--- a/app/services/payola/cancel_subscription.rb
+++ b/app/services/payola/cancel_subscription.rb
@@ -1,11 +1,14 @@
 module Payola
   class CancelSubscription
-    def self.call(subscription)
+    def self.call(subscription, options = {})
       secret_key = Payola.secret_key_for_sale(subscription)
       Stripe.api_key = secret_key
       customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
-      customer.subscriptions.retrieve(subscription.stripe_id,secret_key).delete({},secret_key)
-      subscription.cancel!
+      customer.subscriptions.retrieve(subscription.stripe_id,secret_key).delete(options,secret_key)
+      
+      unless options[:at_period_end] == true
+        subscription.cancel!
+      end
     end
 
   end


### PR DESCRIPTION
This change allows us to pass the `at_period_end` argument to Stripe that signifies that the subscription is to remain active until the end of the subscription period.

```ruby
Payola::CancelSubscription.call(subscription, { at_period_end: true })
```

I'm skipping over the `subscription.cancel!` call if this argument exists, so in order to cancel the subscription the user must monitor for the `customer.subscription.deleted` webhook that Stripe will send upon subscription cancelation:

```ruby
config.subscribe 'customer.subscription.deleted' do |event|
  subscription = Subscription.find_by(stripe_id: event.data.object.id)
  subscription.cancel!
end 
```

Please let me know if this is kosher or if you'd like this handled in a different manner.  Thanks!