### PR TITLE
Trigger error event on form when an error occurs

### DIFF
--- a/app/assets/javascripts/payola/form.js
+++ b/app/assets/javascripts/payola/form.js
@@ -58,7 +58,9 @@ var PayolaPaymentForm = {
 
     showError: function(form, message) {
         $('.payola-spinner').hide();
-        form.find(':submit').prop('disabled', false);
+        $(form).find(':submit')
+               .prop('disabled', false)
+               .trigger('error', message);
         var error_selector = form.data('payola-error-selector');
         if (error_selector) {
             $(error_selector).text(message);

--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -55,7 +55,8 @@ var PayolaSubscriptionCheckout = {
         var error_div = $("#" + options.error_div_id);
         error_div.html(error);
         error_div.show();
-        $(".payola-subscription-checkout-button").prop("disabled", false);
+        $(".payola-subscription-checkout-button").prop("disabled", false)
+                                                 .trigger("error", error);
         $(".payola-subscription-checkout-button-spinner").hide();
         $(".payola-subscription-checkout-button-text").show();
     },

--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -71,7 +71,10 @@ var PayolaOnestepSubscriptionForm = {
 
     showError: function(form, message) {
         $('.payola-spinner').hide();
-        $(form).find(':submit').prop('disabled', false);
+        $(form).find(':submit')
+               .prop('disabled', false)
+               .trigger('error', message);
+
         var error_selector = form.data('payola-error-selector');
         if (error_selector) {
             $(error_selector).text(message);

--- a/app/assets/javascripts/payola/subscription_form_twostep.js
+++ b/app/assets/javascripts/payola/subscription_form_twostep.js
@@ -72,7 +72,9 @@ var PayolaSubscriptionForm = {
 
     showError: function(form, message) {
         $('.payola-spinner').hide();
-        $(form).find(':submit').prop('disabled', false);
+        $(form).find(':submit')
+               .prop('disabled', false)
+               .trigger('error', message);
         var error_selector = form.data('payola-error-selector');
         if (error_selector) {
             $(error_selector).text(message);


### PR DESCRIPTION
Triggering an `error` event will make it easier to customize responses to stripe errors.

In my case I've combined user registration and payment into a single form and I need to remove an `is-submitting` class on the form on error. Happy to write tests for these changes, unfortunately I don't see any js specs in the repo. 