### PR TITLE
Rs/create coupon with stripe

### DIFF
--- a/app/models/payola/coupon.rb
+++ b/app/models/payola/coupon.rb
@@ -1,5 +1,7 @@
 module Payola
   class Coupon < ActiveRecord::Base
     validates_uniqueness_of :code
+    validates :duration, inclusion: { in: %w( once repeating forever ) }
+    validates_presence_of :duration_in_months, if: lambda { duration == "repeating" }
   end
 end

--- a/app/services/payola/create_coupon.rb
+++ b/app/services/payola/create_coupon.rb
@@ -1,0 +1,21 @@
+module Payola
+  class CreateCoupon
+    def self.call(coupon)
+      if coupon.save!
+        begin
+          return Stripe::Coupon.retrieve(coupon.code)
+        rescue Stripe::InvalidRequestError
+          # fall through
+        end
+
+        Stripe::Coupon.create({
+          id:                 coupon.code,
+          amount_off:         coupon.amount_off,
+          percent_off:        coupon.percent_off,
+          duration:           coupon.duration,
+          duration_in_months: coupon.duration_in_months
+        })
+      end
+    end
+  end
+end

--- a/db/migrate/20150721234518_add_amount_off_and_duration_to_payola_coupons.rb
+++ b/db/migrate/20150721234518_add_amount_off_and_duration_to_payola_coupons.rb
@@ -1,0 +1,6 @@
+class AddAmountOffAndDurationToPayolaCoupons < ActiveRecord::Migration
+  def change
+    add_column :payola_coupons, :amount_off, :integer
+    add_column :payola_coupons, :duration, :string
+  end
+end

--- a/db/migrate/20150722013438_add_duration_in_months_to_payola_coupons.rb
+++ b/db/migrate/20150722013438_add_duration_in_months_to_payola_coupons.rb
@@ -1,0 +1,5 @@
+class AddDurationInMonthsToPayolaCoupons < ActiveRecord::Migration
+  def change
+    add_column :payola_coupons, :duration_in_months, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141213205847) do
+ActiveRecord::Schema.define(version: 20150722013438) do
 
   create_table "owners", force: :cascade do |t|
     t.datetime "created_at"
@@ -32,6 +32,9 @@ ActiveRecord::Schema.define(version: 20141213205847) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "active",      default: true
+    t.integer  "amount_off"
+    t.string   "duration"
+    t.integer  "duration_in_months"
   end
 
   create_table "payola_sales", force: :cascade do |t|

--- a/spec/factories/payola_coupons.rb
+++ b/spec/factories/payola_coupons.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
   factory :payola_coupon, :class => 'Payola::Coupon' do
     code "MyString"
     percent_off 1
+    duration "once"
   end
 end

--- a/spec/models/payola/coupon_spec.rb
+++ b/spec/models/payola/coupon_spec.rb
@@ -4,23 +4,78 @@ module Payola
   describe Coupon do
     describe "validations" do
       it "should validate uniqueness of coupon code" do
-        c1 = Coupon.create(code: 'abc')
-        expect(c1.valid?).to be_truthy
+        c1 = create :payola_coupon, code: 'abc'
+        expect(c1).to be_valid
 
-        c2 = Coupon.new(code: 'abc')
-        expect(c2.valid?).to be_falsey
+        c2 = build :payola_coupon, code: 'abc'
+        expect(c2).not_to be_valid
+      end
+
+      context "duration required" do
+        it do
+          c1 = build :payola_coupon, duration: nil
+          expect(c1).not_to be_valid
+        end
+      end
+
+      context "duration inclusion" do
+        it "should allow 'once'" do
+          c1 = build :payola_coupon, duration: 'once'
+          expect(c1).to be_valid
+        end
+
+        it "should allow 'repeating'" do
+          c1 = build :payola_coupon, duration: 'repeating', duration_in_months: 2
+          expect(c1).to be_valid
+        end
+
+        it "should allow 'forever'" do
+          c1 = build :payola_coupon, duration: 'forever'
+          expect(c1).to be_valid
+        end
+
+        it "should not allow 'something' else" do
+          c1 = build :payola_coupon, duration: 'something'
+          expect(c1).not_to be_valid
+        end
+      end
+
+      context "duration_in_months required" do
+        it "should require duration_in_months if duration is 'repeating'" do
+          c1 = build :payola_coupon, duration: 'repeating'
+          expect(c1).not_to be_valid
+        end
+
+        it "should not require duration_in_months if duration is not 'repeating'" do
+          c1 = build :payola_coupon, duration: 'once'
+          expect(c1).to be_valid
+        end
       end
     end
 
     describe "active" do
       it "should allow active flag" do
-        c1 = Coupon.create(code: 'abc', active: false)
+        c1 = build :payola_coupon, active: false
         expect(c1.active?).to be_falsey
       end
 
       it "should be true by default" do
-        c1 = Coupon.create(code: 'abc')
+        c1 = build :payola_coupon
         expect(c1.active?).to be_truthy
+      end
+    end
+
+    describe "amount_off" do
+      it "should allow amount_off" do
+        c1 = build :payola_coupon, amount_off: 999
+        expect(c1.amount_off).not_to be_nil
+      end
+    end
+
+    describe "duration" do
+      it "should allow duration" do
+        c1 = build :payola_coupon, duration: 3
+        expect(c1.duration).not_to be_nil
       end
     end
   end

--- a/spec/services/payola/create_coupon_spec.rb
+++ b/spec/services/payola/create_coupon_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+module Payola
+  describe CreateCoupon do
+    describe "#call" do
+      context "percent off" do
+        let(:coupon) { build :payola_coupon, percent_off: 20 }
+        let(:result) { Stripe::Coupon.retrieve(coupon.code) }
+
+        before { Payola::CreateCoupon.call(coupon) }
+
+        it "should create a coupon at Stripe" do
+          expect(result["id"]).to                 eq(coupon.code)
+          expect(result["duration"]).to           eq(coupon.duration)
+          expect(result["duration_in_months"]).to eq(coupon.duration_in_months)
+          expect(result["percent_off"]).to        eq(coupon.percent_off)
+          expect(result["amount_off"]).to         eq(coupon.amount_off)
+        end
+      end
+
+      context "amount off" do
+        let(:coupon) { build :payola_coupon, percent_off: nil, amount_off: 1000 }
+        let(:result) { Stripe::Coupon.retrieve(coupon.code) }
+
+        before { Payola::CreateCoupon.call(coupon) }
+
+        it "should create a coupon at Stripe" do
+          expect(result["id"]).to                 eq(coupon.code)
+          expect(result["duration"]).to           eq(coupon.duration)
+          expect(result["duration_in_months"]).to eq(coupon.duration_in_months)
+          expect(result["percent_off"]).to        eq(coupon.percent_off)
+          expect(result["amount_off"]).to         eq(coupon.amount_off)
+        end
+      end
+
+      context "exists in stripe" do
+        let(:coupon) { create :payola_coupon, percent_off: nil, amount_off: 1000 }
+
+        it "should skip creating a coupon if there is already a coupon with that code" do
+          Payola::CreateCoupon.call(coupon)
+
+          expect(Stripe::Coupon).to_not receive(:create)
+
+          Payola::CreateCoupon.call(coupon)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds more functionality for working with coupons:

1. add ```amount_off```
2. add ```duration``` & ```duration_in_months``` (with Stripe rules)
3. add CreateCoupon service to sync coupon creation with Stripe