### PR TITLE
allowing coupons on changing subscriptions per Stripe instructions

### DIFF
--- a/app/services/payola/change_subscription_plan.rb
+++ b/app/services/payola/change_subscription_plan.rb
@@ -1,6 +1,6 @@
 module Payola
   class ChangeSubscriptionPlan
-    def self.call(subscription, plan)
+    def self.call(subscription, plan, coupon_code = nil)
       secret_key = Payola.secret_key_for_sale(subscription)
       old_plan = subscription.plan
 
@@ -9,9 +9,11 @@ module Payola
         sub = customer.subscriptions.retrieve(subscription.stripe_id)
 
         prorate = plan.respond_to?(:should_prorate?) ? plan.should_prorate?(subscription) : true
+        prorate = false if coupon_code.present?
 
         sub.plan = plan.stripe_id
         sub.prorate = prorate
+        sub.coupon = coupon_code if coupon_code.present?
         sub.save
 
         subscription.plan = plan

--- a/app/services/payola/change_subscription_plan.rb
+++ b/app/services/payola/change_subscription_plan.rb
@@ -5,14 +5,9 @@ module Payola
       old_plan = subscription.plan
 
       begin
-        customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
-        sub = customer.subscriptions.retrieve(subscription.stripe_id)
-
-        prorate = plan.respond_to?(:should_prorate?) ? plan.should_prorate?(subscription) : true
-        prorate = false if coupon_code.present?
-
+        sub = retrieve_subscription_for_customer(subscription, secret_key)
         sub.plan = plan.stripe_id
-        sub.prorate = prorate
+        sub.prorate = should_prorate?(subscription, plan, coupon_code)
         sub.coupon = coupon_code if coupon_code.present?
         sub.save
 
@@ -26,6 +21,17 @@ module Payola
       end
 
       subscription
+    end
+
+    def self.retrieve_subscription_for_customer(subscription, secret_key)
+      customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
+      customer.subscriptions.retrieve(subscription.stripe_id)
+    end
+
+    def self.should_prorate?(subscription, plan, coupon_code)
+      prorate = plan.respond_to?(:should_prorate?) ? plan.should_prorate?(subscription) : true
+      prorate = false if coupon_code.present?
+      prorate
     end
   end
 end

--- a/spec/services/payola/change_subscription_plan_spec.rb
+++ b/spec/services/payola/change_subscription_plan_spec.rb
@@ -12,18 +12,81 @@ module Payola
         token = StripeMock.generate_card_token({})
         @subscription = create(:subscription, plan: @plan1, stripe_token: token)
         StartSubscription.call(@subscription)
-        Payola::ChangeSubscriptionPlan.call(@subscription, @plan2)
       end
 
-      it "should change the plan on the stripe subscription" do
-        customer = Stripe::Customer.retrieve(@subscription.stripe_customer_id)
-        sub = customer.subscriptions.retrieve(@subscription.stripe_id)
+      context "default" do
+        before { Payola::ChangeSubscriptionPlan.call(@subscription, @plan2) }
 
-        expect(sub.plan.id).to eq @plan2.stripe_id
+        it "should change the plan on the stripe subscription" do
+          customer = Stripe::Customer.retrieve(@subscription.stripe_customer_id)
+          sub = customer.subscriptions.retrieve(@subscription.stripe_id)
+
+          expect(sub.plan.id).to eq @plan2.stripe_id
+        end
+
+        it "should change the plan on the payola subscription" do
+          expect(@subscription.reload.plan).to eq @plan2
+        end
       end
 
-      it "should change the plan on the payola subscription" do
-        expect(@subscription.reload.plan).to eq @plan2
+      context "coupon" do
+        before do
+          @sub = Stripe::Subscription.new
+
+          allow(@sub).to receive(:save).and_return(true) # coupon value is wiped when save is called
+          allow(ChangeSubscriptionPlan).to receive(:retrieve_subscription_for_customer).and_return(@sub)
+        end
+
+        context "not set" do
+          before do
+            Payola::ChangeSubscriptionPlan.call(@subscription, @plan2)
+          end
+
+          it "should not have the coupon" do
+            expect(@sub.try(:coupon)).to be_nil
+          end
+        end
+
+        context "set" do
+          before do
+            @coupon = build :payola_coupon
+            Payola::ChangeSubscriptionPlan.call(@subscription, @plan2, @coupon)
+          end
+
+          it "should have the coupon" do
+            expect(@sub.coupon.code).to eq(@coupon.code)
+          end
+        end
+      end
+    end
+
+    describe ".should_prorate?" do
+      let(:subscription)  { build :subscription }
+      let(:plan)          { build :subscription_plan }
+      let(:coupon_code)   { nil }
+      let(:prorate)       { ChangeSubscriptionPlan.should_prorate?(subscription, plan, coupon_code) }
+
+      context "plan doesn't respond to should_prorate?" do
+        it { expect(prorate).to eq(true) }
+      end
+
+      context "plan.should_prorate? is false" do
+        before { allow(plan).to receive(:should_prorate?).and_return(false) }
+
+        it { expect(prorate).to eq(false) }
+      end
+
+      context "plan.should_prorate? is true" do
+        before { allow(plan).to receive(:should_prorate?).and_return(true) }
+
+        it { expect(prorate).to eq(true) }
+      end
+
+      context "plan.should_prorate? is true, coupon overrides" do
+        let(:coupon_code) { build :payola_coupon }
+        before { allow(plan).to receive(:should_prorate?).and_return(true) }
+
+        it { expect(prorate).to eq(false) }
       end
     end
   end


### PR DESCRIPTION
Allows coupon to be applied to changing subscription, and turns off prorating in that scenario per Stripe instructions.