### PR TITLE
Support for subscription creation with trial_end and optional stripeToken

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -9,7 +9,6 @@ module Payola
     validates_presence_of :email
     validates_presence_of :plan_id
     validates_presence_of :plan_type
-    validates_presence_of :stripe_token
     validates_presence_of :currency
 
     belongs_to :plan,  polymorphic: true

--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -14,6 +14,7 @@ module Payola
         s.signed_custom_fields = params[:signed_custom_fields]
         s.setup_fee = params[:setup_fee]
         s.quantity = params[:quantity]
+        s.trial_end = params[:trial_end]
 
         s.owner = owner
         s.amount = plan.amount

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -24,6 +24,7 @@ module Payola
           plan: subscription.plan.stripe_id,
           quantity: subscription.quantity
         }
+        create_params[:trial_end] = subscription.trial_end.to_i if subscription.trial_end.present?
         create_params[:coupon] = subscription.coupon if subscription.coupon.present?
         stripe_sub = customer.subscriptions.create(create_params)
 
@@ -63,6 +64,10 @@ module Payola
           customer = Stripe::Customer.retrieve(customer_id, secret_key)
           return customer unless customer.try(:deleted)
         end
+      end
+
+      unless subscription.stripe_token.present?
+        raise "stripeToken required for new customer subscription"
       end
 
       customer_create_params = {

--- a/spec/factories/payola_subscriptions.rb
+++ b/spec/factories/payola_subscriptions.rb
@@ -13,8 +13,8 @@ FactoryGirl.define do
     current_period_start "2014-11-04 22:34:39"
     current_period_end "2014-11-04 22:34:39"
     ended_at "2014-11-04 22:34:39"
-    trial_start "2014-11-04 22:34:39"
-    trial_end "2014-11-04 22:34:39"
+    trial_start Time.now
+    trial_end Time.now + 7.days
     canceled_at "2014-11-04 22:34:39"
     email "jeremy@octolabs.com"
     stripe_token "yyz123"

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -21,7 +21,7 @@ module Payola
 
       it "should validate stripe_token" do
         subscription = build(:subscription, stripe_token: nil)
-        expect(subscription.valid?).to be false
+        expect(subscription.valid?).to be true
       end
 
     end


### PR DESCRIPTION
This change adds support for the trial_end attribute when creating a subscription, and also changes the stripeToken value to be optional.

This former allows creation of a subscription with a trial period, and the later allows creation of a subscription without needing a user's credit card information if the user already exists in Stripe (for administrative purposes, or for future purchases with Stripe who will use the customer's attached card as the payment source).

I put an exception in place if the stripeToken value is not passed and the customer does not exist in Stripe.

Creating a subscription in this manner would be done like:

```ruby
subscription_params = {
  plan: subscription_plan,
  stripeEmail: user_email,
  quantity: 1,
  trial_end: 7.days.from_now
}
 
Payola::CreateSubscription.call(subscription_params, user)
```