### PR TITLE
Allows users to update their credit card on resubscription

### DIFF
--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -26,6 +26,7 @@ module Payola
         }
         create_params[:trial_end] = subscription.trial_end.to_i if subscription.trial_end.present?
         create_params[:coupon] = subscription.coupon if subscription.coupon.present?
+        create_params[:source] = subscription.stripe_token if subscription.stripe_token.present?
         stripe_sub = customer.subscriptions.create(create_params)
 
         card = customer.sources.data.first

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -93,8 +93,6 @@ module Payola
         StartSubscription.call(subscription2)
         expect(subscription.card_last4).to_not eq subscription2.card_last4
         expect(subscription.exp_year).to_not eq subscription2.exp_year
-
-        binding.pry
       end
     end
   end

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -81,6 +81,21 @@ module Payola
         expect(ii.amount).to eq 100
         expect(ii.description).to eq 'Random Mystery Fee'
       end
+
+      it "should update the user's card information if a stripeToken is present" do
+        plan = create(:subscription_plan)
+        card_token = StripeMock.generate_card_token(last4: '1212', exp_year: Time.now + 2.years)
+        subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: card_token, owner: user)
+        StartSubscription.call(subscription)
+
+        card_token2 = StripeMock.generate_card_token(last4: '2121', exp_year: Time.now + 1.years)
+        subscription2 = create(:subscription, state: 'processing', plan: plan, stripe_token: card_token2, owner: user)
+        StartSubscription.call(subscription2)
+        expect(subscription.card_last4).to_not eq subscription2.card_last4
+        expect(subscription.exp_year).to_not eq subscription2.exp_year
+
+        binding.pry
+      end
     end
   end
 end


### PR DESCRIPTION
When an existing card becomes starts to fail, a user cannot re-subscribe.

Current scenario:
A subscription customer with an active account has a card that is no longer valid.
Their subscription is cancelled and they are required to re-subscribe.
They enter updated credit card information.
The old information is still used and the subscription plan fails.

This commit sets the source on the stripe subscription if the stripeToken is present.