### PR TITLE
Add config option to determine whether to create plans in Stripe

### DIFF
--- a/app/models/concerns/payola/plan.rb
+++ b/app/models/concerns/payola/plan.rb
@@ -12,7 +12,7 @@ module Payola
 
       validates_uniqueness_of :stripe_id
 
-      before_create :create_stripe_plan
+      before_create :create_stripe_plan, if: -> { Payola.create_stripe_plans }
 
       has_many :subscriptions, :class_name => "Payola::Subscription"
 

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -29,7 +29,8 @@ module Payola
       :default_currency,
       :additional_charge_attributes,
       :guid_generator,
-      :pdf_receipt
+      :pdf_receipt,
+      :create_stripe_plans
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?
@@ -88,6 +89,7 @@ module Payola
       self.additional_charge_attributes = lambda { |sale, customer| { } }
       self.pdf_receipt = false
       self.guid_generator = lambda { SecureRandom.random_number(1_000_000_000).to_s(32) }
+      self.create_stripe_plans = true
     end
 
     def register_sellable(klass)

--- a/spec/concerns/plan_spec.rb
+++ b/spec/concerns/plan_spec.rb
@@ -28,20 +28,42 @@ module Payola
       expect(subscription_plan.valid?).to be false
     end
 
-    it "should create the plan at stripe before the model is created" do
-      subscription_plan = build(:subscription_plan)
-      Payola::CreatePlan.should_receive(:call)
-      subscription_plan.save!
+    context "with Payola.create_stripe_plans set to true" do
+      before { Payola.create_stripe_plans = true }
+
+      it "should create the plan at stripe before the model is created" do
+        subscription_plan = build(:subscription_plan)
+        Payola::CreatePlan.should_receive(:call)
+        subscription_plan.save!
+      end
+
+      it "should not try to create the plan at stripe before the model is updated" do
+        subscription_plan = build(:subscription_plan)
+        subscription_plan.save!
+        subscription_plan.name = "new name"
+
+        Payola::CreatePlan.should_not_receive(:call)
+        subscription_plan.save!
+      end
     end
 
-    it "should not try to create the plan at stripe before the model is updated" do
-      subscription_plan = build(:subscription_plan)
-      subscription_plan.save!
-      subscription_plan.name = "new name"
+    context "with Payola.create_stripe_plans set to false" do
+      before { Payola.create_stripe_plans = false }
 
-      Payola::CreatePlan.should_not_receive(:call)
-      subscription_plan.save!
+      it "should not try to create the plan at stripe before the model is created" do
+        subscription_plan = build(:subscription_plan)
+        Payola::CreatePlan.should_not_receive(:call)
+        subscription_plan.save!
+      end
+
+      it "should not try to create the plan at stripe before the model is updated" do
+        subscription_plan = build(:subscription_plan)
+        subscription_plan.save!
+        subscription_plan.name = "new name"
+
+        Payola::CreatePlan.should_not_receive(:call)
+        subscription_plan.save!
+      end
     end
-
   end
 end

--- a/spec/payola_spec.rb
+++ b/spec/payola_spec.rb
@@ -135,4 +135,11 @@ module Payola
       expect(Payola.additional_charge_attributes.call(sale, customer)).to eq({})
     end
   end
+
+  describe "#create_stripe_plans" do
+    it "defaults to true" do
+      Payola.reset!
+      expect(Payola.create_stripe_plans).to be true
+    end
+  end
 end


### PR DESCRIPTION
Make this default to true for backwards compatibility.

This is necessary if you create plans in your test suite (as opposed to only using fixtures).

We could also set the template initializer to include this, possibly commented out:

```ruby
if Rails.env.test?
  config.create_stripe_plans = false
end
```

What do you think? Unexpectedly creating the plans in Stripe is definitely a bit of a gotcha at present.