### PR TITLE
Fix jQuery XHR JSON error handling

### DIFF
--- a/app/assets/javascripts/payola/checkout_button.js
+++ b/app/assets/javascripts/payola/checkout_button.js
@@ -47,7 +47,7 @@ var PayolaCheckout = {
             url: options.base_path + "/buy/" + options.product_class + "/" + options.product_permalink,
             data: form.serialize(),
             success: function(data) { PayolaCheckout.poll(data.guid, 60, options); },
-            error: function(data) { PayolaCheckout.showError(data.responseJSON.error, options); }
+            error: function(data) { PayolaCheckout.showError(jQuery.parseJSON(data.responseText).error, options); }
         });
     },
 
@@ -80,7 +80,7 @@ var PayolaCheckout = {
             type: "GET",
             url: options.base_path + "/status/" + guid,
             success: handler,
-            error: function(xhr){ handler(xhr.responseJSON) }
+            error: function(xhr){ handler(jQuery.parseJSON(xhr.responseText)) }
         });
     }
 };

--- a/app/assets/javascripts/payola/form.js
+++ b/app/assets/javascripts/payola/form.js
@@ -34,7 +34,7 @@ var PayolaPaymentForm = {
                 url: base_path + "/buy/" + product + "/" + permalink,
                 data: data_form.serialize(),
                 success: function(data) { PayolaPaymentForm.poll(form, 60, data.guid, base_path); },
-                error: function(data) { PayolaPaymentForm.showError(form, data.responseJSON.error); }
+                error: function(data) { PayolaPaymentForm.showError(form, jQuery.parseJSON(data.responseText).error); }
             });
         }
     },

--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -47,7 +47,7 @@ var PayolaSubscriptionCheckout = {
             url: form.attr('action'),
             data: form.serialize(),
             success: function(data) { PayolaSubscriptionCheckout.poll(data.guid, 60, options); },
-            error: function(data) { PayolaSubscriptionCheckout.showError(data.responseJSON.error, options); }
+            error: function(data) { PayolaSubscriptionCheckout.showError(jQuery.parseJSON(data.responseText).error, options); }
         });
     },
 
@@ -81,7 +81,7 @@ var PayolaSubscriptionCheckout = {
             type: "GET",
             url: options.base_path + "/subscription_status/" + guid,
             success: handler,
-            error: function(xhr) { handler(xhr.responseJSON) }
+            error: function(xhr) { handler(jQuery.parseJSON(xhr.responseText)) }
         });
     }
 };

--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -40,7 +40,7 @@ var PayolaOnestepSubscriptionForm = {
                 url: action,
                 data: form.serialize(),
                 success: function(data) { PayolaOnestepSubscriptionForm.poll(form, 60, data.guid, base_path); },
-                error: function(data) { PayolaOnestepSubscriptionForm.showError(form, data.responseJSON.error); }
+                error: function(data) { PayolaOnestepSubscriptionForm.showError(form, jQuery.parseJSON(data.responseText).error); }
             });
         }
     },
@@ -57,7 +57,7 @@ var PayolaOnestepSubscriptionForm = {
             }
         };
         var errorHandler = function(jqXHR){
-            PayolaOnestepSubscriptionForm.showError(form, jqXHR.responseJSON.error);
+            PayolaOnestepSubscriptionForm.showError(form, jQuery.parseJSON(jqXHR.responseText).error);
         };
 
         $.ajax({

--- a/app/assets/javascripts/payola/subscription_form_register.js
+++ b/app/assets/javascripts/payola/subscription_form_register.js
@@ -37,7 +37,7 @@ var PayolaRegistrationForm = {
             url: "/users",
             data: form.serialize(),
             success: function(data) { PayolaRegistrationForm.poll(form, 60, data.guid, base_path); },
-            error: function(data) { PayolaRegistrationForm.showError(form, data.responseJSON.error); }
+            error: function(data) { PayolaRegistrationForm.showError(form, jQuery.parseJSON(data.responseText).error); }
         });
     },
 
@@ -55,8 +55,9 @@ var PayolaRegistrationForm = {
             }
         };
         var errorHandler = function(jqXHR){
-          if(jqXHR.responseJSON.status === "errored"){
-            PayolaRegistrationForm.showError(form, jqXHR.responseJSON.error);
+          var responseJSON = jQuery.parseJSON(jqXHR.responseText);
+          if(responseJSON.status === "errored"){
+            PayolaRegistrationForm.showError(form, responseJSON.error);
           }
         };
 

--- a/app/assets/javascripts/payola/subscription_form_twostep.js
+++ b/app/assets/javascripts/payola/subscription_form_twostep.js
@@ -37,7 +37,7 @@ var PayolaSubscriptionForm = {
                 url: base_path + "/subscribe/" + plan_type + "/" + plan_id,
                 data: data_form.serialize(),
                 success: function(data) { PayolaSubscriptionForm.poll(form, 60, data.guid, base_path); },
-                error: function(data) { PayolaSubscriptionForm.showError(form, data.responseJSON.error); }
+                error: function(data) { PayolaSubscriptionForm.showError(form, jQuery.parseJSON(data.responseText).error); }
             });
         }
     },
@@ -56,8 +56,9 @@ var PayolaSubscriptionForm = {
             }
         };
         var errorHandler = function(jqXHR){
-          if(jqXHR.responseJSON.status === "errored"){
-            PayolaSubscriptionForm.showError(form, jqXHR.responseJSON.error);
+          var responseJSON = jQuery.parseJSON(jqXHR.responseText);
+          if(responseJSON.status === "errored"){
+            PayolaSubscriptionForm.showError(form, responseJSON.error);
           }
         };
 

--- a/app/views/payola/transactions/_form.html.erb
+++ b/app/views/payola/transactions/_form.html.erb
@@ -108,7 +108,7 @@
           url: "<%= payola.buy_url(product_class: sale.product.product_class, permalink: sale.product.permalink) %>",
           data: $('#payment-form').serialize(),
           success: function(data) { poll(data.guid, 60) },
-          error: function(data) { showError(data.responseJSON.error) }
+          error: function(data) { showError(jQuery.parseJSON(data.responseText).error) }
         });
       }
     }


### PR DESCRIPTION
Annoyingly, jQuery doesn't parse the response as JSON if the status code
is an error (http://stackoverflow.com/q/12310702/117104), even though
the server response's Content-Type is correctly set to application/json.
So in our XHR error handlers, xhr.responseJSON was always undefined.

Manually parse the responseText as JSON using jQuery.parseJSON().

Note that this won't behave correctly if the server doesn't return JSON
(eg. if there's a 500 error for some reason and it returns an HTML error
page or something, or there's a 404 and it renders 'nothing').It would
be good to handle those cases. I think we'd want to DRY up the error
handlers first though as it's a bit verbose to handle all these cases
correctly.