### PR TITLE
Allow Plan#trial_period_days attribute to remain optional

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -130,7 +130,7 @@ module Payola
     def conditional_stripe_token
       return true if plan.nil?
       if (plan.amount > 0 )
-        if plan.trial_period_days.nil? or ( plan.trial_period_days and !(plan.trial_period_days > 0) )
+        if plan.respond_to?(:trial_period_days) and (plan.trial_period_days.nil? or ( plan.trial_period_days and !(plan.trial_period_days > 0) ))
           errors.add(:base, 'No Stripe token is present for a paid plan') if stripe_token.nil?
         end
       end


### PR DESCRIPTION
Don't assume it's defined - call `#respond_to?` first to check the attribute exists in the same way as we do for other optional attributes in the CreatePlan service.

Otherwise anyone that isn't using this attribute will hit an exception in the `conditional_stripe_token` validation.