### PR TITLE
Ensure Payola.create_stripe_plans global gets set back to true

### DIFF
--- a/spec/concerns/plan_spec.rb
+++ b/spec/concerns/plan_spec.rb
@@ -48,7 +48,8 @@ module Payola
     end
 
     context "with Payola.create_stripe_plans set to false" do
-      before { Payola.create_stripe_plans = false }
+      before(:example) { Payola.create_stripe_plans = false }
+      after(:example) { Payola.create_stripe_plans = true }
 
       it "should not try to create the plan at stripe before the model is created" do
         subscription_plan = build(:subscription_plan)


### PR DESCRIPTION
This caused the test suite failures I was seeing in #161 (there may be others, but after fixing this issue I couldn't find another test ordering seed which caused the suite to fail).

Some tests currently expect plans to be implicitly created in Stripe. Depending on the order that the suite ran in, `Payola.create_stripe_plans` could be set to false when these examples ran, which would prevent plans from being created in Stripe. This caused failures.

For now, make sure we set `Payola.create_stripe_plans` back to the default of `true`, so that tests that depend on this behaviour will keep working whatever order the suite is run in.