### PR TITLE
Pass at_period_end param to CancelSubscription, support it in subscriptions/_cancel partial

### DIFF
--- a/app/controllers/payola/subscriptions_controller.rb
+++ b/app/controllers/payola/subscriptions_controller.rb
@@ -21,7 +21,7 @@ module Payola
 
     def destroy
       subscription = Subscription.find_by!(guid: params[:guid])
-      Payola::CancelSubscription.call(subscription, at_period_end: params[:at_period_end])
+      Payola::CancelSubscription.call(subscription, at_period_end: ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include?(params[:at_period_end]))
       redirect_to confirm_subscription_path(subscription)
     end
 

--- a/app/controllers/payola/subscriptions_controller.rb
+++ b/app/controllers/payola/subscriptions_controller.rb
@@ -21,7 +21,7 @@ module Payola
 
     def destroy
       subscription = Subscription.find_by!(guid: params[:guid])
-      Payola::CancelSubscription.call(subscription)
+      Payola::CancelSubscription.call(subscription, at_period_end: params[:at_period_end])
       redirect_to confirm_subscription_path(subscription)
     end
 

--- a/app/views/payola/subscriptions/_cancel.html.erb
+++ b/app/views/payola/subscriptions/_cancel.html.erb
@@ -5,9 +5,11 @@
   confirm_text = local_assigns.fetch :confirm_text, "Are you sure?"
   disabled = !subscription.active?
   url = local_assigns.fetch :url, payola.cancel_subscription_path(subscription.guid)
+  at_period_end = local_assigns.fetch :at_period_end, false
 %>
 
 <%= form_tag url, :method => :delete do %>
+  <%= hidden_field_tag :at_period_end, at_period_end %>
   <%= button_tag type: 'submit', class: button_class, disabled: disabled, data: { confirm: confirm_text } do %>
     <%= content_tag(:span, button_text, class: 'payola-subscription-cancel-buton-text') %>
   <% end -%>

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -111,6 +111,11 @@ module Payola
         expect(response).to redirect_to "/subdir/payola/confirm_subscription/#{@subscription.guid}"
         expect(request.flash[:alert]).to eq 'You cannot modify this subscription.'
       end
+
+      it "should pass the at_period_end param through to Payola::CancelSubscription" do
+        Payola::CancelSubscription.should_receive(:call).with(instance_of(Payola::Subscription), at_period_end: true)
+        delete :destroy, guid: @subscription.guid, at_period_end: true
+      end
     end
 
     describe '#change_plan' do

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -112,9 +112,9 @@ module Payola
         expect(request.flash[:alert]).to eq 'You cannot modify this subscription.'
       end
 
-      it "should pass the at_period_end param through to Payola::CancelSubscription" do
+      it "coerce the at_period_end param to a boolean, and pass it through to Payola::CancelSubscription" do
         Payola::CancelSubscription.should_receive(:call).with(instance_of(Payola::Subscription), at_period_end: true)
-        delete :destroy, guid: @subscription.guid, at_period_end: true
+        delete :destroy, guid: @subscription.guid, at_period_end: 'true'
       end
     end
 


### PR DESCRIPTION
We already have support in `CancelSubscription` for the `at_period_end` param, but you had to call that service manually to be able to pass that argument through.

Add support for an `at_period_end` param in the stock `subscriptions/_cancel` partial, and pass it through to the `CancelSubscription` service from the `SubscriptionsController#destroy` method.