### PR TITLE
Feature/accept tax percent for subs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 coverage
 .rspec
 *.sublime-*
+.idea

--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -16,7 +16,7 @@ var PayolaSubscriptionCheckout = {
             token: function(token) { PayolaSubscriptionCheckout.tokenHandler(token, options); },
             name: options.name,
             description: options.description,
-            amount: options.price,
+            amount: options.price+(options.price*options.tax_percent),
             panelLabel: options.panel_label,
             allowRememberMe: options.allow_remember_me,
             zipCode: options.verify_zip_code,
@@ -35,6 +35,7 @@ var PayolaSubscriptionCheckout = {
         form.append($('<input type="hidden" name="stripeToken">').val(token.id));
         form.append($('<input type="hidden" name="stripeEmail">').val(token.email));
         form.append($('<input type="hidden" name="quantity">').val(options.quantity));
+        form.append($('<input type="hidden" name="tax_percent">').val(options.tax_percent));
         if (options.signed_custom_fields) {
           form.append($('<input type="hidden" name="signed_custom_fields">').val(options.signed_custom_fields));
         }

--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -16,7 +16,7 @@ var PayolaSubscriptionCheckout = {
             token: function(token) { PayolaSubscriptionCheckout.tokenHandler(token, options); },
             name: options.name,
             description: options.description,
-            amount: options.price+(options.price*options.tax_percent),
+            amount: options.price+(options.price*(options.tax_percent/100)),
             panelLabel: options.panel_label,
             allowRememberMe: options.allow_remember_me,
             zipCode: options.verify_zip_code,

--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -15,6 +15,7 @@ module Payola
         s.setup_fee = params[:setup_fee]
         s.quantity = params[:quantity]
         s.trial_end = params[:trial_end]
+        s.tax_percent = params[:tax_percent]
 
         s.owner = owner
         s.amount = plan.amount

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -22,7 +22,8 @@ module Payola
 
         create_params = {
           plan: subscription.plan.stripe_id,
-          quantity: subscription.quantity
+          quantity: subscription.quantity,
+          tax_percent: subscription.tax_percent
         }
         create_params[:trial_end] = subscription.trial_end.to_i if subscription.trial_end.present?
         create_params[:coupon] = subscription.coupon if subscription.coupon.present?

--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -25,7 +25,7 @@
   form_id = "#{button_id}-form"
 
   currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
-  tax_percent = (local_assigns.fetch :tax_percent ? plan.currency : Payola.default_tax_percent).to_i
+  tax_percent = local_assigns.fetch(:tax_percent, Payola.default_tax_percent).to_i
 
   error_div_id = local_assigns.fetch :error_div_id, ''
   if error_div_id.present?

--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -25,6 +25,7 @@
   form_id = "#{button_id}-form"
 
   currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
+  tax_percent = (local_assigns.fetch :tax_percent ? plan.currency : Payola.default_tax_percent).to_i
 
   error_div_id = local_assigns.fetch :error_div_id, ''
   if error_div_id.present?
@@ -46,6 +47,7 @@
     name: name,
     description: description,
     currency: currency,
+    tax_percent: tax_percent,
     plan_image_path: plan_image_path,
     publishable_key: Payola.publishable_key_for_sale(sale),
     panel_label: panel_label,

--- a/db/migrate/20150930164135_add_tax_percent_to_payola_subscriptions.rb
+++ b/db/migrate/20150930164135_add_tax_percent_to_payola_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddTaxPercentToPayolaSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :payola_subscriptions, :tax_percent, :integer
+  end
+end

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -27,6 +27,7 @@ module Payola
       :subscribables,
       :charge_verifier,
       :default_currency,
+      :default_tax_percent,
       :additional_charge_attributes,
       :guid_generator,
       :pdf_receipt,
@@ -84,6 +85,7 @@ module Payola
       self.publishable_key_retriever = lambda { |sale| Payola.publishable_key }
       self.support_email = 'sales@example.com'
       self.default_currency = 'usd'
+      self.default_tax_percent = nil
       self.sellables = {}
       self.subscribables = {}
       self.additional_charge_attributes = lambda { |sale, customer| { } }

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -10,6 +10,9 @@ module Payola
     end
 
     describe '#create' do
+
+      let(:tax_percent) { 20 }
+
       it "should pass args to CreateSubscription" do
         subscription = double
         subscription.should_receive(:save).and_return(true)
@@ -23,6 +26,7 @@ module Payola
         CreateSubscription.should_receive(:call).with(
           'plan_class' => 'subscription_plan',
           'plan_id' => @plan.id.to_s,
+          'tax_percent' => tax_percent.to_s,
           'controller' => 'payola/subscriptions',
           'action' => 'create',
           'plan' => @plan,
@@ -31,7 +35,7 @@ module Payola
           'affiliate' => nil
         ).and_return(subscription)
 
-        post :create, plan_class: @plan.plan_class, plan_id: @plan.id
+        post :create, plan_class: @plan.plan_class, plan_id: @plan.id, tax_percent: tax_percent
 
         expect(response.status).to eq 200
         parsed_body = JSON.load(response.body)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141213205847) do
+ActiveRecord::Schema.define(version: 20150930164135) do
 
   create_table "owners", force: :cascade do |t|
     t.datetime "created_at"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 20141213205847) do
     t.text     "customer_address"
     t.text     "business_address"
     t.integer  "setup_fee"
+    t.integer  "tax_percent"
   end
 
   add_index "payola_subscriptions", ["guid"], name: "index_payola_subscriptions_on_guid"

--- a/spec/services/payola/create_subscription_spec.rb
+++ b/spec/services/payola/create_subscription_spec.rb
@@ -11,30 +11,32 @@ module Payola
       it "should create a subscription and queue the job" do
         expect(Payola).to receive(:queue!)
 
-        sale = CreateSubscription.call(
+        subscription = CreateSubscription.call(
           stripeEmail: 'pete@bugsplat.info',
           stripeToken: 'test_tok',
-          plan: @plan
+          plan: @plan,
+          tax_percent: 20
         )
 
-        expect(sale.email).to eq 'pete@bugsplat.info'
-        expect(sale.stripe_token).to eq 'test_tok'
-        expect(sale.plan_id).to eq @plan.id
-        expect(sale.plan).to eq @plan
-        expect(sale.plan_type).to eq 'SubscriptionPlan'
-        expect(sale.currency).to eq 'usd'
+        expect(subscription.email).to eq 'pete@bugsplat.info'
+        expect(subscription.stripe_token).to eq 'test_tok'
+        expect(subscription.plan_id).to eq @plan.id
+        expect(subscription.plan).to eq @plan
+        expect(subscription.plan_type).to eq 'SubscriptionPlan'
+        expect(subscription.currency).to eq 'usd'
+        expect(subscription.tax_percent).to eq 20
       end
             
       it "should include the affiliate if given" do
         affiliate = create(:payola_affiliate)
-        sale = CreateSubscription.call(
+        subscription = CreateSubscription.call(
           email: 'pete@bugsplat.info',
           stripeToken: 'test_tok',
           plan: @plan,
           affiliate: affiliate
         )
 
-        expect(sale.affiliate).to eq affiliate
+        expect(subscription.affiliate).to eq affiliate
       end
     end
   end


### PR DESCRIPTION
* This resolves the issue when setting up subscriptions and needing to apply a tax percent for the subscription as per issue #103 

* You can either set the default tax_percent using 
```ruby
Payola.configure do |config|
  config.default_tax_percent = 20
end
```
* or you can pass in the tax_percent to the subscription checkout partial as a whole number (as per Stripe docs)
```ruby
<%= render 'payola/subscriptions/checkout', plan: plan, email: email, tax_percent: 20 %>
```

The price including vat is then displayed when using checkout.

