### PR TITLE
Functionality to manage multiple cards and update customer attributes

### DIFF
--- a/app/controllers/payola/cards_controller.rb
+++ b/app/controllers/payola/cards_controller.rb
@@ -1,0 +1,36 @@
+module Payola
+  class CardsController < ApplicationController
+  
+    before_filter :check_modify_permissions, only: [:create, :destroy]
+    
+    def create
+      if params[:customer_id].present? && params[:stripeToken].present?
+        Payola::CreateCard.call(params[:customer_id], params[:stripeToken])
+        redirect_to :back, notice: "Succesfully created new card"
+      else
+        redirect_to :back, alert: "Could not create new card"
+      end  
+    end
+
+    def destroy
+      if params[:id].present? && params[:customer_id].present?
+        Payola::DestroyCard.call(params[:id], params[:customer_id])
+        redirect_to :back, notice: "Succesfully removed the card"
+      else
+        redirect_to :back, alert: "Could not remove the card"
+      end  
+    end
+
+    private
+
+    def check_modify_permissions
+      if self.respond_to?(:payola_can_modify_customer?)
+        redirect_to(
+          :back,
+          alert: "You cannot modify this customer."
+        ) and return unless self.payola_can_modify_customer?(params[:customer_id])
+      end
+    end
+
+  end
+end

--- a/app/controllers/payola/customers_controller.rb
+++ b/app/controllers/payola/customers_controller.rb
@@ -1,0 +1,33 @@
+module Payola
+  class CustomersController < ApplicationController
+     
+    before_filter :check_modify_permissions, only: [:update]
+ 
+    def update
+      if params[:id].present?
+        Payola::UpdateCustomer.call(params[:id], customer_params)
+        redirect_to :back, notice: "Succesfully updated customer"
+      else
+        redirect_to :back, alert: "Could not update customer"
+      end  
+    end
+
+    private
+
+    # Only including default_source for now, though other attributes can be used 
+    # (https://stripe.com/docs/api#update_customer)
+    def customer_params
+      params.require(:customer).permit(:default_source)
+    end
+
+    def check_modify_permissions
+      if self.respond_to?(:payola_can_modify_customer?)
+        redirect_to(
+          :back,
+          alert: "You cannot modify this customer."
+        ) and return unless self.payola_can_modify_customer?(params[:id])
+      end
+    end
+
+  end
+end

--- a/app/services/payola/create_card.rb
+++ b/app/services/payola/create_card.rb
@@ -1,0 +1,13 @@
+module Payola
+  class CreateCard
+    def self.call(stripe_customer_id, token)
+      secret_key = Payola.secret_key
+      card_fingerprint = Stripe::Token.retrieve(token, secret_key).try(:card).try(:fingerprint)
+      customer = Stripe::Customer.retrieve(stripe_customer_id, secret_key)
+
+      unless customer.sources.select{|source| source.fingerprint == card_fingerprint}.any?
+        customer.sources.create(source: token)
+      end
+    end
+  end
+end

--- a/app/services/payola/destroy_card.rb
+++ b/app/services/payola/destroy_card.rb
@@ -1,0 +1,9 @@
+module Payola
+  class DestroyCard
+    def self.call(card_id, stripe_customer_id)
+      secret_key = Payola.secret_key
+      customer = Stripe::Customer.retrieve(stripe_customer_id, secret_key)
+      customer.sources.retrieve(card_id).delete()
+    end
+  end
+end

--- a/app/services/payola/update_customer.rb
+++ b/app/services/payola/update_customer.rb
@@ -1,0 +1,9 @@
+module Payola
+  class UpdateCustomer
+    def self.call(stripe_customer_id, options)
+      secret_key = Payola.secret_key
+      customer = Stripe::Customer.retrieve(stripe_customer_id, secret_key)
+      customer.save(options)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Payola::Engine.routes.draw do
-  match '/buy/:product_class/:permalink' => 'transactions#create',   via: :post, as: :buy
-  match '/confirm/:guid'                 => 'transactions#show',     via: :get,  as: :confirm
-  match '/status/:guid'                  => 'transactions#status',   via: :get,  as: :status
+  match '/buy/:product_class/:permalink'  => 'transactions#create',   via: :post, as: :buy
+  match '/confirm/:guid'                  => 'transactions#show',     via: :get,  as: :confirm
+  match '/status/:guid'                   => 'transactions#status',   via: :get,  as: :status
 
   match '/subscribe/:plan_class/:plan_id' => 'subscriptions#create',   via: :post,   as: :subscribe
   match '/confirm_subscription/:guid'     => 'subscriptions#show',     via: :get,    as: :confirm_subscription
@@ -11,5 +11,10 @@ Payola::Engine.routes.draw do
   match '/change_quantity/:guid'          => 'subscriptions#change_quantity', via: :post, as: :change_subscription_quantity
   match '/update_card/:guid'              => 'subscriptions#update_card', via: :post, as: :update_card
 
+  match '/update_customer/:id'            => 'customers#update', via: :post, as: :update_customer
+
+  match '/create_card/:customer_id'       => 'cards#create', via: :post, as: :create_card
+  match '/destroy_card/:id/:customer_id'  => 'cards#destroy', via: :delete, as: :destroy_card
+  
   mount StripeEvent::Engine => '/events'
 end

--- a/spec/controllers/payola/cards_controller_spec.rb
+++ b/spec/controllers/payola/cards_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module Payola
+  describe CardsController do
+    routes { Payola::Engine.routes }
+  
+    before do
+      request.env["HTTP_REFERER"] = "/my/cards"
+    end
+
+    describe '#create' do
+      let(:stripe_helper) { StripeMock.create_test_helper }
+
+      let(:customer) {
+        Stripe::Customer.create({
+          email: 'johnny@appleseed.com',
+        })
+      }
+
+      it "should pass args to CreateCard" do
+        expect(CreateCard).to receive(:call)
+        post :create, customer_id: customer.id, stripeToken: StripeMock.generate_card_token({})
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/cards"
+        expect(flash[:notice]).to eq "Succesfully created new card"
+        expect(flash[:alert]).to_not be_present
+      end
+
+      it "should fail when missing a token" do
+        expect(CreateCard).to_not receive(:call)
+        post :create, customer_id: customer.id, stripeToken: nil
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/cards"
+        expect(flash[:alert]).to eq "Could not create new card"
+        expect(flash[:notice]).to_not be_present
+      end
+    end
+
+    describe '#destroy' do
+      let(:stripe_helper) { StripeMock.create_test_helper }
+
+      let(:customer) {
+        Stripe::Customer.create({
+          email: 'johnny@appleseed.com',
+          source: stripe_helper.generate_card_token
+        })
+      }
+
+      it "should pass args to DestroyCard" do
+        expect(DestroyCard).to receive(:call)
+        delete :destroy, id: customer.sources.first.id, customer_id: customer.id
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/cards"
+        expect(flash[:notice]).to eq "Succesfully removed the card"
+        expect(flash[:alert]).to_not be_present
+      end
+    end
+
+  end
+end

--- a/spec/controllers/payola/customers_controller_spec.rb
+++ b/spec/controllers/payola/customers_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+module Payola
+  describe CustomersController do
+    routes { Payola::Engine.routes }
+  
+    before do
+      request.env["HTTP_REFERER"] = "/my/cards"
+    end
+
+    describe '#update' do
+      let(:stripe_helper) { StripeMock.create_test_helper }
+
+      let(:customer) {
+        Stripe::Customer.create({
+          email: 'johnny@appleseed.com',
+          card: stripe_helper.generate_card_token({last4: '2233', exp_year: '2021', exp_month: '11', brand: 'JCB'})
+        })
+      }
+
+      it "should pass args to UpdateCustomer" do
+        expect(UpdateCustomer).to receive(:call)
+        post :update, id: customer.id, customer: { default_source: "1234" }
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/cards"
+        expect(flash[:notice]).to eq "Succesfully updated customer"
+        expect(flash[:alert]).to_not be_present
+      end
+
+    end
+  end
+end

--- a/spec/services/payola/create_card_spec.rb
+++ b/spec/services/payola/create_card_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Payola
+  describe CreateCard do
+    let(:stripe_helper) { StripeMock.create_test_helper }
+  
+    let(:customer) {
+      Stripe::Customer.create({
+        email: 'johnny@appleseed.com',
+      })
+    }
+
+    describe "#call" do
+      it "creates the new card" do
+        Payola.secret_key = 'sk_test_12345'
+
+        token = StripeMock.generate_card_token({last4: '1111', exp_year: '2099', exp_month: '12', brand: 'JWH'})
+        expect{Payola::CreateCard.call(customer.id, token)}.to_not raise_error
+        updated_customer = Stripe::Customer.retrieve(customer.id, Payola.secret_key)
+        expect(updated_customer.sources.first.last4).to eq('1111')
+      end
+
+      it "does not create duplicate cards" do
+        Payola.secret_key = 'sk_test_12345'
+
+        token = StripeMock.generate_card_token({last4: '1111', exp_year: '2099', exp_month: '12', brand: 'JWH'})
+        token2 = StripeMock.generate_card_token({last4: '1111', exp_year: '2099', exp_month: '12', brand: 'JWH'})
+
+        expect{Payola::CreateCard.call(customer.id, token)}.to_not raise_error
+
+        updated_customer = Stripe::Customer.retrieve(customer.id, Payola.secret_key)
+        expect(updated_customer.sources.count).to eq 1
+
+        expect{Payola::CreateCard.call(customer.id, token2)}.to_not raise_error
+
+        updated_customer = Stripe::Customer.retrieve(customer.id, Payola.secret_key)
+        expect(updated_customer.sources.count).to eq 1
+      end
+
+    end
+  end
+end

--- a/spec/services/payola/destroy_card_spec.rb
+++ b/spec/services/payola/destroy_card_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module Payola
+  describe DestroyCard do
+    let(:stripe_helper) { StripeMock.create_test_helper }
+  
+    let(:customer) {
+      Stripe::Customer.create({
+        email: 'johnny@appleseed.com',
+        source: stripe_helper.generate_card_token
+      })
+    }
+
+    describe "#call" do
+      it "creates the new card" do
+        Payola.secret_key = 'sk_test_12345'
+        
+        card_id = customer.sources.first.id
+  
+        expect{Payola::DestroyCard.call(card_id, customer.id)}.to_not raise_error
+        updated_customer = Stripe::Customer.retrieve(customer.id, Payola.secret_key)
+        expect(updated_customer.sources.count).to eq(0)
+        expect(updated_customer.default_source).to eq(nil)
+      end
+  
+    end
+  end
+end

--- a/spec/services/payola/update_customer_spec.rb
+++ b/spec/services/payola/update_customer_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+module Payola
+  describe UpdateCustomer do
+    let(:stripe_helper) { StripeMock.create_test_helper }
+  
+    let(:customer) {
+      Stripe::Customer.create({
+        email: 'johnny@appleseed.com',
+        card: stripe_helper.generate_card_token({last4: '2233', exp_year: '2021', exp_month: '11', brand: 'JCB'})
+      })
+    }
+
+    describe "#call" do
+      it "updates the customer" do
+        Payola.secret_key = 'sk_test_12345'
+
+        options = { default_source: "1234" }
+        expect{Payola::UpdateCustomer.call(customer.id, options)}.to_not raise_error
+        updated_customer = Stripe::Customer.retrieve(customer.id, Payola.secret_key)
+        expect(updated_customer.default_source).to eq "1234"
+      end
+  
+    end
+  end
+end


### PR DESCRIPTION
This change adds two features:

- The ability to add and remove credit cards from a customer's source list
- The ability to update a customer's attributes

Currently, I am only allowing the customer `default_source` attribute to be passed, but more can be added by editing the `customer_params` method in `CustomerController`.

I also have added logic to prevent duplicate cards from being created.

Similar to the `SubscriptionController`, I have added support for a method in `ApplicationController` called `payola_can_modify_customer?` that can prevent unauthorized users from modifying others' customer objects or cards.  The method can be implemented in `ApplicationController` like:

```ruby
def payola_can_modify_customer?(stripe_customer_id)
  current_user.stripe_customer_id == stripe_customer_id
end 
```

I've left the `update_card` method in `SubscriptionsController` as is, as it is useful to completely replace a single card holistically, wheres the functionality implemented above is used to manage multiple cards for a single customer.

Some examples of requests against the new functionality:

```ruby
# Remove a card
 = link_to "Remove Card", payola.destroy_card_path(card[:id], customer_id: current_user.stripe_customer_id), method: :delete, data: { confirm: "Are you sure you wish to remove this card?" } 

# Set a card as the primary card (more ideally you could also submit a form)
= link_to "Make Primary Card", payola.update_customer_path(current_user.stripe_customer_id, "customer[default_source]" => card[:id]), method: :post

# Add a card via Stripe Checkout
<script src="https://checkout.stripe.com/checkout.js"></script>
= form_tag payola.create_card_path(current_user.stripe_customer_id), hash_of_form_options do
...
end