### PR TITLE
Make outputting Stripe checkout JS and CSS optional

### DIFF
--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -17,6 +17,7 @@
   billing_address = local_assigns.fetch :billing_address, false
   shipping_address = local_assigns.fetch :shipping_address, false
   form_url = local_assigns.fetch :form_url, payola.subscribe_path(plan_class: plan_class, plan_id: plan_id)
+  include_stripe_checkout_assets = local_assigns.fetch :include_stripe_checkout_assets, true
 
   sale = Payola::Subscription.new(plan: plan)
 
@@ -67,8 +68,10 @@
   html_hash["id"] = form_id
 %>
 
-<script src="https://checkout.stripe.com/checkout.js"></script>
-<link rel="stylesheet" href="https://checkout.stripe.com/v3/checkout/button.css"></link>
+<% if include_stripe_checkout_assets %>
+  <script src="https://checkout.stripe.com/checkout.js"></script>
+  <link rel="stylesheet" href="https://checkout.stripe.com/v3/checkout/button.css"></link>
+<% end %>
 
 <%= form_tag form_url, html_hash do %>
   <button class="<%= button_class %> payola-subscription-checkout-button" id="<%= button_id %>">


### PR DESCRIPTION
Previously, if you rendered more than one payola/subscriptions/checkout partial in a single page, Stripe Checkout's JS and CSS files will be included multiple times. This doesn't seem to break anything, but it would be better if it didn't happen.

Add `include_stripe_checkout_assets` option when rendering the partial, which defaults to true for backwards compatibility.

This seems a bit dirty. I think it would be better to instruct people to include the Checkout JS and CSS in their own application layout (or wherever they need to) rather than having an option for the partial, but we can't change this without a major version bump as that would break backwards compatibility in a big way.