### PR TITLE
Take optional stripe_customer_id to be used when creating a subscription

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -128,6 +128,8 @@ module Payola
     end
 
     def conditional_stripe_token
+      # Don't require a Stripe token if we're creating a subscription for an existing Stripe customer
+      return true if stripe_customer_id.present?
       return true if plan.nil?
       if (plan.amount > 0 )
         if plan.respond_to?(:trial_period_days) and (plan.trial_period_days.nil? or ( plan.trial_period_days and !(plan.trial_period_days > 0) ))

--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -128,6 +128,8 @@ module Payola
     end
 
     def conditional_stripe_token
+      # Don't require a Stripe token if the subscription has an owner - we'll try to reuse the Stripe customer from an existing successful subscription
+      return true if owner.present?
       # Don't require a Stripe token if we're creating a subscription for an existing Stripe customer
       return true if stripe_customer_id.present?
       return true if plan.nil?

--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -4,9 +4,16 @@ module Payola
       plan = params[:plan]
       affiliate = params[:affiliate]
 
+      if params[:stripe_customer_id].present?
+        customer = Stripe::Customer.retrieve(params[:stripe_customer_id])
+        email = customer.email
+      else
+        email = params[:stripeEmail]
+      end
+
       sub = Payola::Subscription.new do |s|
         s.plan = plan
-        s.email = params[:stripeEmail]
+        s.email = email
         s.stripe_token = params[:stripeToken] if plan.amount > 0
         s.affiliate_id = affiliate.try(:id)
         s.currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
@@ -16,6 +23,7 @@ module Payola
         s.quantity = params[:quantity]
         s.trial_end = params[:trial_end]
         s.tax_percent = params[:tax_percent]
+        s.stripe_customer_id = customer.id if customer
 
         s.owner = owner
         s.amount = plan.amount

--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -27,6 +27,7 @@
 
   currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
   tax_percent = local_assigns.fetch(:tax_percent, Payola.default_tax_percent).to_i
+  stripe_customer_id = local_assigns.fetch(:stripe_customer_id, nil)
 
   error_div_id = local_assigns.fetch :error_div_id, ''
   if error_div_id.present?
@@ -56,7 +57,8 @@
     email: email,
     verify_zip_code: verify_zip_code,
     billing_address: billing_address,
-    shipping_address: shipping_address
+    shipping_address: shipping_address,
+    stripe_customer_id: stripe_customer_id
   }
 
   raw_data[:signed_custom_fields] = sale.verifier.generate(custom_fields) if custom_fields

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -97,7 +97,7 @@ module Payola
 
     describe '#destroy' do
       before :each do
-        @subscription = create(:subscription, :state => :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
       end
       it "call Payola::CancelSubscription and redirect" do
         Payola::CancelSubscription.should_receive(:call)
@@ -124,7 +124,7 @@ module Payola
 
     describe '#change_plan' do
       before :each do
-        @subscription = create(:subscription, state: :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
         @plan = create(:subscription_plan)
       end
 
@@ -158,7 +158,7 @@ module Payola
 
     describe '#change_quantity' do
       before :each do
-        @subscription = create(:subscription, state: :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
         @plan = create(:subscription_plan)
       end
 
@@ -192,7 +192,7 @@ module Payola
 
     describe "#update_card" do
       before :each do
-        @subscription = create(:subscription, state: :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
         @plan = create(:subscription_plan)
       end
 

--- a/spec/factories/payola_subscriptions.rb
+++ b/spec/factories/payola_subscriptions.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
     status "MyString"
     owner_type "Owner"
     owner_id 1
-    stripe_customer_id "MyString"
     cancel_at_period_end false
     current_period_start "2014-11-04 22:34:39"
     current_period_end "2014-11-04 22:34:39"

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -30,6 +30,20 @@ module Payola
         expect(subscription.valid?).to be true
       end
       
+      it "should validate nil stripe_token when the subscription owner is present" do
+        plan = create(:subscription_plan)
+        plan.amount = 0
+        subscription = build(:subscription, stripe_token: nil, owner: build(:sale))
+        expect(subscription.valid?).to be true
+      end
+
+      it "should validate nil stripe_token when the stripe_customer_id is specified" do
+        plan = create(:subscription_plan)
+        plan.amount = 0
+        subscription = build(:subscription, stripe_token: nil, stripe_customer_id: "cus_123456")
+        expect(subscription.valid?).to be true
+      end
+
       it "should validate nil stripe_token on free plan" do
         plan = create(:subscription_plan)
         plan.amount = 0

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -70,10 +70,10 @@ module Payola
         deleted_customer_id = subscription.reload.stripe_customer_id
         Stripe::Customer.retrieve(deleted_customer_id).delete
 
-        subscription2 = create(:subscription, state: 'processing', plan: plan, owner: user)
+        subscription2 = create(:subscription, state: 'processing', plan: plan, stripe_token: nil, owner: user)
+        expect(subscription2).to receive(:fail!)
         StartSubscription.call(subscription2)
-        expect(subscription2.reload.stripe_customer_id).to_not be_nil
-        expect(subscription2.reload.stripe_customer_id).to_not eq deleted_customer_id
+        expect(subscription2.reload.error).to eq "stripeToken required for new customer subscription"
       end
 
       it "should create an invoice item with a setup fee" do


### PR DESCRIPTION
At the moment, when you create a Subscription we look for an existing Subscription for the same owner, and if we find one, re-use the Stripe customer from the first subscription.

Extend this functionality by allowing you to specify the Stripe customer id to use on the subscription when creating it. For accounts that have made a purchase from you before this allows you to re-use the same Stripe customer when they choose to start a Subscription.

We probably want to handle re-using the Stripe customer from existing Sale records in the database in the same way.