### PR TITLE
Listen for customer.subscription.deleted webhooks and cancel the associated subscription

### DIFF
--- a/app/services/payola/subscription_deleted.rb
+++ b/app/services/payola/subscription_deleted.rb
@@ -1,0 +1,11 @@
+module Payola
+  class SubscriptionDeleted
+    def self.call(event)
+      stripe_sub = event.data.object
+
+      sub = Payola::Subscription.find_by!(stripe_id: stripe_sub.id)
+
+      sub.cancel!
+    end
+  end
+end

--- a/lib/payola/engine.rb
+++ b/lib/payola/engine.rb
@@ -33,6 +33,7 @@ module Payola
         config.subscribe 'invoice.payment_succeeded',     Payola::InvoicePaid
         config.subscribe 'invoice.payment_failed',        Payola::InvoiceFailed
         config.subscribe 'customer.subscription.updated', Payola::SyncSubscription
+        config.subscribe 'customer.subscription.deleted', Payola::SubscriptionDeleted
       end
     end
   end

--- a/spec/services/payola/subscription_deleted_spec.rb
+++ b/spec/services/payola/subscription_deleted_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+module Payola
+  describe SubscriptionDeleted do
+    it "should cancel the subscription that was deleted" do
+      sub = create(:subscription, state: 'active')
+      event = StripeMock.mock_webhook_event('customer.subscription.deleted', id: sub.stripe_id)
+      expect { Payola::SubscriptionDeleted.call(event) }.to change { sub.reload.state }.from('active').to('canceled')
+    end
+  end
+end


### PR DESCRIPTION
The customer's subscription can be deleted if they progress through the dunning cycle, and you have configured your account to cancel their subscription after their final failure to pay (see https://stripe.com/docs/guides/subscriptions#payment-failures for details).

It can also be deleted if you manually cancel their subscription via the Stripe Dashboard.

In both cases we should listen for Stripe's customer.subscription.deleted webhook and cancel the Payola::Subscription as we do if the customer chooses to end their subscription via the CancelSubscription service.

Otherwise, their Payola::Subscription only ends up in the canceled state if the customer has explicitly initiated canceling it themselves.