### PR TITLE
Take coupon local and submit it as a param in subscriptions/_checkout

### DIFF
--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -35,6 +35,7 @@ var PayolaSubscriptionCheckout = {
         form.append($('<input type="hidden" name="stripeToken">').val(token.id));
         form.append($('<input type="hidden" name="stripeEmail">').val(token.email));
         form.append($('<input type="hidden" name="quantity">').val(options.quantity));
+        form.append($('<input type="hidden" name="coupon">').val(options.coupon));
         form.append($('<input type="hidden" name="tax_percent">').val(options.tax_percent));
         if (options.signed_custom_fields) {
           form.append($('<input type="hidden" name="signed_custom_fields">').val(options.signed_custom_fields));

--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -5,6 +5,7 @@
   plan_class = plan.plan_class
   plan_id = plan.id
   quantity = local_assigns.fetch :quantity, 1
+  coupon = local_assigns.fetch :coupon, nil
   price = local_assigns.fetch :price, plan.amount * quantity
   name = local_assigns.fetch :name, plan.name
   description = local_assigns.fetch :description, "#{name} (#{formatted_price(price)} per month)"
@@ -44,6 +45,7 @@
     plan_class: plan_class,
     plan_id: plan_id,
     quantity: quantity,
+    coupon: coupon,
     price: price,
     name: name,
     description: description,


### PR DESCRIPTION
If you want to use the `payola/subscriptions/_checkout` partial, there wasn't a way to specify a coupon to be used with the subscription. Take coupon local variable in this partial and submit it to the server. The `SubscriptionsController` already handles this param correctly.