### PR TITLE
Support for custom return paths after customer/card actions

### DIFF
--- a/app/controllers/payola/cards_controller.rb
+++ b/app/controllers/payola/cards_controller.rb
@@ -6,18 +6,18 @@ module Payola
     def create
       if params[:customer_id].present? && params[:stripeToken].present?
         Payola::CreateCard.call(params[:customer_id], params[:stripeToken])
-        redirect_to :back, notice: "Succesfully created new card"
+        redirect_to return_to, notice: "Succesfully created new card"
       else
-        redirect_to :back, alert: "Could not create new card"
+        redirect_to return_to, alert: "Could not create new card"
       end  
     end
 
     def destroy
       if params[:id].present? && params[:customer_id].present?
         Payola::DestroyCard.call(params[:id], params[:customer_id])
-        redirect_to :back, notice: "Succesfully removed the card"
+        redirect_to return_to, notice: "Succesfully removed the card"
       else
-        redirect_to :back, alert: "Could not remove the card"
+        redirect_to return_to, alert: "Could not remove the card"
       end  
     end
 
@@ -26,10 +26,14 @@ module Payola
     def check_modify_permissions
       if self.respond_to?(:payola_can_modify_customer?)
         redirect_to(
-          :back,
+          return_to,
           alert: "You cannot modify this customer."
         ) and return unless self.payola_can_modify_customer?(params[:customer_id])
       end
+    end
+
+    def return_to
+      params[:return_to] || :back
     end
 
   end

--- a/app/controllers/payola/customers_controller.rb
+++ b/app/controllers/payola/customers_controller.rb
@@ -6,9 +6,9 @@ module Payola
     def update
       if params[:id].present?
         Payola::UpdateCustomer.call(params[:id], customer_params)
-        redirect_to :back, notice: "Succesfully updated customer"
+        redirect_to return_to, notice: "Succesfully updated customer"
       else
-        redirect_to :back, alert: "Could not update customer"
+        redirect_to return_to, alert: "Could not update customer"
       end  
     end
 
@@ -23,10 +23,14 @@ module Payola
     def check_modify_permissions
       if self.respond_to?(:payola_can_modify_customer?)
         redirect_to(
-          :back,
+          return_to,
           alert: "You cannot modify this customer."
         ) and return unless self.payola_can_modify_customer?(params[:id])
       end
+    end
+
+    def return_to
+      params[:return_to] || :back
     end
 
   end

--- a/spec/controllers/payola/cards_controller_spec.rb
+++ b/spec/controllers/payola/cards_controller_spec.rb
@@ -5,6 +5,7 @@ module Payola
     routes { Payola::Engine.routes }
   
     before do
+      Payola.secret_key = 'sk_test_12345'
       request.env["HTTP_REFERER"] = "/my/cards"
     end
 
@@ -36,6 +37,13 @@ module Payola
         expect(flash[:alert]).to eq "Could not create new card"
         expect(flash[:notice]).to_not be_present
       end
+
+      it "should return to the passed return path" do
+        post :create, customer_id: customer.id, stripeToken: StripeMock.generate_card_token({}), return_to: "/another/path"
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/another/path"
+      end
     end
 
     describe '#destroy' do
@@ -56,6 +64,13 @@ module Payola
         expect(response).to redirect_to "/my/cards"
         expect(flash[:notice]).to eq "Succesfully removed the card"
         expect(flash[:alert]).to_not be_present
+      end
+
+      it "should return to the passed return path" do
+        delete :destroy, id: customer.sources.first.id, customer_id: customer.id, return_to: "/another/path"
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/another/path"
       end
     end
 

--- a/spec/controllers/payola/customers_controller_spec.rb
+++ b/spec/controllers/payola/customers_controller_spec.rb
@@ -5,6 +5,7 @@ module Payola
     routes { Payola::Engine.routes }
   
     before do
+      Payola.secret_key = 'sk_test_12345'
       request.env["HTTP_REFERER"] = "/my/cards"
     end
 
@@ -26,6 +27,13 @@ module Payola
         expect(response).to redirect_to "/my/cards"
         expect(flash[:notice]).to eq "Succesfully updated customer"
         expect(flash[:alert]).to_not be_present
+      end
+
+      it "should return to the passed return path" do
+        post :update, id: customer.id, customer: { default_source: "1234" }, return_to: "/another/path"
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/another/path"
       end
 
     end


### PR DESCRIPTION
This is a small change that adds support for custom return paths after performing a card or customer action.

To use it, you can pass a location via `return_to` and it will return there rather than `:back`

It can be used like:

```ruby
= link_to "Make Primary Card", payola.update_customer_path(current_user.stripe_customer_id, 
"customer[default_source]" => card[:id]), return_to: after_primary_card_path(current_user)), 
 method: :post
```