### PR TITLE
Allow sales to be refunded on the client side

### DIFF
--- a/app/services/payola/process_refund.rb
+++ b/app/services/payola/process_refund.rb
@@ -1,0 +1,20 @@
+module Payola
+  class ProcessRefund
+    def self.call(guid)
+      sale = Sale.find_by(guid: guid)
+      
+      begin
+        secret_key = Payola.secret_key
+    
+        charge = Stripe::Charge.retrieve(sale.stripe_id, secret_key)
+        charge.refund
+
+        sale.refund!
+      rescue Stripe::InvalidRequestError, Stripe::StripeError, RuntimeError => e
+        sale.errors[:base] << e.message
+      end
+
+      sale
+    end
+  end
+end

--- a/lib/generators/payola/templates/initializer.rb
+++ b/lib/generators/payola/templates/initializer.rb
@@ -23,6 +23,6 @@ Payola.configure do |config|
   # Keep this subscription unless you want to disable refund handling
   config.subscribe 'charge.refunded' do |event|
     sale = Payola::Sale.find_by(stripe_id: event.data.object.id)
-    sale.refund!
+    sale.refund! unless sale.refunded?
   end
 end

--- a/spec/services/payola/process_refund_spec.rb
+++ b/spec/services/payola/process_refund_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module Payola
+  describe ProcessRefund do
+    describe "#call" do
+      before :each do 
+        Payola.secret_key = 'sk_test_12345'
+      end
+
+      it "should refund the sale" do
+        charge = Stripe::Charge.create({
+          :amount => 40,
+          :currency => "usd",
+          :source => StripeMock.generate_card_token({}),
+        })
+        
+        sale = create(:sale, stripe_id: charge.id, amount: charge.amount, state: :finished)
+        
+        expect(Payola::Sale).to receive(:find_by).with(guid: sale.guid).and_return(sale)
+        Payola::ProcessRefund.call(sale.guid)
+        expect(sale.reload.refunded?).to eq(true)
+      end
+
+      it "should not refund the sale if an error occurs" do
+        sale = create(:sale, stripe_id: "this doesn't exist", amount: "10", state: :finished)
+        
+        expect(Payola::Sale).to receive(:find_by).with(guid: sale.guid).and_return(sale)
+        returned_sale = Payola::ProcessRefund.call(sale.guid)
+        expect(returned_sale.errors.any?).to eq(true)
+        expect(sale.reload.refunded?).to eq(false)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This change implements a `ProcessRefund` service to execute a refund with Stripe.

The existing webhook listener is still useful to listen for and sync refund events that happen on Stripe's side, but I needed a way to issue a refund locally.

Since creating a refund issues a `charge.refunded` callback, I've added the conditional `unless sale.refunded?` to the initializer template to prevent state change attempts against an already refunded sale.

This service can be called by:

```ruby
Payola::ProcessRefund.call(sale.guid) # returns the sale with any errors attached

or

Payola.queue!(Payola::ProcessRefund, sale.guid)
```