### PR TITLE
Support for using existing customer for sales and subscriptions

### DIFF
--- a/app/services/payola/create_sale.rb
+++ b/app/services/payola/create_sale.rb
@@ -12,6 +12,7 @@ module Payola
         s.affiliate_id = affiliate.try(:id)
         s.currency = product.respond_to?(:currency) ? product.currency : Payola.default_currency
         s.signed_custom_fields = params[:signed_custom_fields]
+        s.stripe_customer_id = params[:stripe_customer_id]
 
         if coupon
           s.coupon = coupon

--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -16,6 +16,7 @@ module Payola
         s.quantity = params[:quantity]
         s.trial_end = params[:trial_end]
         s.tax_percent = params[:tax_percent]
+        s.stripe_customer_id = params[:stripe_customer_id]
 
         s.owner = owner
         s.amount = plan.amount

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -62,6 +62,11 @@ module Payola
     end
 
     def find_or_create_customer
+      if subscription.stripe_customer_id.present?    
+        customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
+        return customer unless customer.try(:deleted)
+      end
+
       subs = Subscription.where(owner: subscription.owner).where("state in ('active', 'canceled')") if subscription.owner
 
       if subs && subs.length >= 1

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -124,7 +124,7 @@ module Payola
 
     describe '#change_plan' do
       before :each do
-        @subscription = create(:subscription, state: :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: 'MyString')
         @plan = create(:subscription_plan)
       end
 
@@ -158,7 +158,7 @@ module Payola
 
     describe '#change_quantity' do
       before :each do
-        @subscription = create(:subscription, state: :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: 'MyString')
         @plan = create(:subscription_plan)
       end
 
@@ -192,7 +192,7 @@ module Payola
 
     describe "#update_card" do
       before :each do
-        @subscription = create(:subscription, state: :active)
+        @subscription = create(:subscription, state: :active, stripe_customer_id: 'MyString')
         @plan = create(:subscription_plan)
       end
 

--- a/spec/factories/payola_subscriptions.rb
+++ b/spec/factories/payola_subscriptions.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
     status "MyString"
     owner_type "Owner"
     owner_id 1
-    stripe_customer_id "MyString"
     cancel_at_period_end false
     current_period_start "2014-11-04 22:34:39"
     current_period_end "2014-11-04 22:34:39"

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -52,7 +52,7 @@ module Payola
         deleted_customer_id = subscription.reload.stripe_customer_id
         Stripe::Customer.retrieve(deleted_customer_id).delete
 
-        subscription2 = create(:subscription, state: 'processing', plan: plan, owner: user)
+        subscription2 = create(:subscription, state: 'processing', plan: plan, owner: user, stripe_customer_id: 'MyString')
         StartSubscription.call(subscription2)
         expect(subscription2.reload.stripe_customer_id).to_not be_nil
         expect(subscription2.reload.stripe_customer_id).to_not eq deleted_customer_id


### PR DESCRIPTION
This change allows the customer's `stripe_customer_id` to be set in `CreateSale` and `CreateSubscription`.  With this set, Payola will find an existing customer and use it's default source as the payment method rather than creating a new customer on Stripe's end.

When a sale is processed, `ChargeCard` is called and either finds the Stripe customer by the sale's `stripe_customer_id`, or it creates a new customer.  It was possible to create the sale, set this value manually, then process the sale, but this change allows us to simply pass the parameter through the controller without the manual step before processing.

When a subscription is processed, `StartSubscription` checks to see if the user has any other subscriptions with a `stripe_customer_id`, and if so uses that as the customer, or otherwise creates a new customer.  This change allows us to firstly use the subscription's `stripe_customer_id` if it is set.

There is a real pain point in the existing code that required me to make this change (though I think this change is cleaner as it doesn't require a manual step between creating an processing):  `CreateSale` simply returns the sale so the user can call `ProcessSale` on it.  However, `CreateSubscription` calls `ProcessSubscription` itself [shown here](https://github.com/peterkeen/payola/blob/748ec1a6c39dedd168fcc0f857900ecb14f0a3e5/app/services/payola/create_subscription.rb#L24), which prevents the user from setting any attributes like `stripe_customer_id` before processing the subscription.  Why the difference between the two?