### PR TITLE
Take optional stripe_customer_id when creating a sale

### DIFF
--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -5,7 +5,7 @@ module Payola
       affiliate = params[:affiliate]
 
       if params[:stripe_customer_id].present?
-        customer = Stripe::Customer.retrieve(params[:stripe_customer_id])
+        customer = Stripe::Customer.retrieve(params[:stripe_customer_id], Payola.secret_key)
         email = customer.email
       else
         email = params[:stripeEmail]

--- a/app/views/payola/transactions/_checkout.html.erb
+++ b/app/views/payola/transactions/_checkout.html.erb
@@ -16,6 +16,7 @@
   billing_address = local_assigns.fetch :billing_address, false
   shipping_address = local_assigns.fetch :shipping_address, false
   bitcoin = local_assigns.fetch :bitcoin, false
+  stripe_customer_id = local_assigns.fetch :stripe_customer_id, nil
 
   sale = Payola::Sale.new(product: sellable)
 
@@ -52,7 +53,8 @@
     verify_zip_code: verify_zip_code,
     billing_address: billing_address,
     shipping_address: shipping_address,
-    bitcoin: bitcoin
+    bitcoin: bitcoin,
+    stripe_customer_id: stripe_customer_id
   }
 
   raw_data[:signed_custom_fields] = sale.verifier.generate(custom_fields) if custom_fields


### PR DESCRIPTION
In the same vein as #170 by @nfm, this change allows a `stripe_customer_id` to be passed through and attached and processed on a sale object.  This allows a user to make multiple purchases without entering credit card information.

I did need to add ` Payola.secret_key` inside of `CreateSubscription` (which was missing from #170, maybe it's not needed if configured a certain way) as well as use it in `CreateSale`.