### PR TITLE
Only cancel subscription in SubscriptionDeleted if it can be canceled

### DIFF
--- a/app/services/payola/subscription_deleted.rb
+++ b/app/services/payola/subscription_deleted.rb
@@ -5,7 +5,7 @@ module Payola
 
       sub = Payola::Subscription.find_by!(stripe_id: stripe_sub.id)
 
-      sub.cancel!
+      sub.cancel! if sub.may_cancel?
     end
   end
 end


### PR DESCRIPTION
The default webhook handler for 'customer.subscription.deleted' calls `SubscriptionDeleted`, which would previously always attempt to `#cancel!` the subscription.

However, it's possible (and likely) that the subscription has already been canceled. If the user cancels their subscription through your app, the subscription will be canceled by the `CancelSubscription` service, and later a webhook will arrive and call `SubscriptionDeleted`, which will attempt to cancel the subscription a second time.

Only attempt to cancel the subscription via the webhook if the subscription is in a state that can transition to canceled.