### PR TITLE
Fix RSpec Warnings

### DIFF
--- a/spec/concerns/plan_spec.rb
+++ b/spec/concerns/plan_spec.rb
@@ -33,7 +33,7 @@ module Payola
 
       it "should create the plan at stripe before the model is created" do
         subscription_plan = build(:subscription_plan)
-        Payola::CreatePlan.should_receive(:call)
+        expect(Payola::CreatePlan).to receive(:call)
         subscription_plan.save!
       end
 
@@ -42,7 +42,7 @@ module Payola
         subscription_plan.save!
         subscription_plan.name = "new name"
 
-        Payola::CreatePlan.should_not_receive(:call)
+        expect(Payola::CreatePlan).to_not receive(:call)
         subscription_plan.save!
       end
     end
@@ -53,7 +53,7 @@ module Payola
 
       it "should not try to create the plan at stripe before the model is created" do
         subscription_plan = build(:subscription_plan)
-        Payola::CreatePlan.should_not_receive(:call)
+        expect(Payola::CreatePlan).to_not receive(:call)
         subscription_plan.save!
       end
 
@@ -62,7 +62,7 @@ module Payola
         subscription_plan.save!
         subscription_plan.name = "new name"
 
-        Payola::CreatePlan.should_not_receive(:call)
+        expect(Payola::CreatePlan).to_not receive(:call)
         subscription_plan.save!
       end
     end

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -15,15 +15,15 @@ module Payola
 
       it "should pass args to CreateSubscription" do
         subscription = double
-        subscription.should_receive(:save).and_return(true)
-        subscription.should_receive(:guid).at_least(1).times.and_return(1)
-        subscription.should_receive(:error).and_return(nil)
+        expect(subscription).to receive(:save).and_return(true)
+        expect(subscription).to receive(:guid).at_least(1).times.and_return(1)
+        expect(subscription).to receive(:error).and_return(nil)
         errors = double
-        errors.should_receive(:full_messages).and_return([])
-        subscription.should_receive(:errors).and_return(errors)
-        subscription.should_receive(:state).and_return('pending')
+        expect(errors).to receive(:full_messages).and_return([])
+        expect(subscription).to receive(:errors).and_return(errors)
+        expect(subscription).to receive(:state).and_return('pending')
 
-        CreateSubscription.should_receive(:call).with(
+        expect(CreateSubscription).to receive(:call).with(
           'plan_class' => 'subscription_plan',
           'plan_id' => @plan.id.to_s,
           'tax_percent' => tax_percent.to_s,
@@ -45,17 +45,17 @@ module Payola
       describe "with an error" do
         it "should return an error in json" do
           subscription = double
-          subscription.should_receive(:save).and_return(false)
+          expect(subscription).to receive(:save).and_return(false)
           error = double
-          error.should_receive(:full_messages).and_return(['done did broke'])
-          subscription.should_receive(:errors).and_return(error)
-          subscription.should_receive(:state).and_return('errored')
-          subscription.should_receive(:error).and_return('')
-          subscription.should_receive(:guid).and_return('blah')
+          expect(error).to receive(:full_messages).and_return(['done did broke'])
+          expect(subscription).to receive(:errors).and_return(error)
+          expect(subscription).to receive(:state).and_return('errored')
+          expect(subscription).to receive(:error).and_return('')
+          expect(subscription).to receive(:guid).and_return('blah')
 
 
-          CreateSubscription.should_receive(:call).and_return(subscription)
-          Payola.should_not_receive(:queue!)
+          expect(CreateSubscription).to receive(:call).and_return(subscription)
+          expect(Payola).to_not receive(:queue!)
 
           post :create, plan_class: @plan.plan_class, plan_id: @plan.id
 
@@ -100,7 +100,7 @@ module Payola
         @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
       end
       it "call Payola::CancelSubscription and redirect" do
-        Payola::CancelSubscription.should_receive(:call)
+        expect(Payola::CancelSubscription).to receive(:call)
         delete :destroy, guid: @subscription.guid
         # TODO : Figure out why this needs to be a hardcoded path.
         # Why doesn't subscription_path(@subscription) work?
@@ -117,7 +117,7 @@ module Payola
       end
 
       it "coerce the at_period_end param to a boolean, and pass it through to Payola::CancelSubscription" do
-        Payola::CancelSubscription.should_receive(:call).with(instance_of(Payola::Subscription), at_period_end: true)
+        expect(Payola::CancelSubscription).to receive(:call).with(instance_of(Payola::Subscription), at_period_end: true)
         delete :destroy, guid: @subscription.guid, at_period_end: 'true'
       end
     end

--- a/spec/controllers/payola/transactions_controller_spec.rb
+++ b/spec/controllers/payola/transactions_controller_spec.rb
@@ -13,14 +13,14 @@ module Payola
       it "should pass args to CreateSale and queue the job" do
         sale = double
         errors = double
-        errors.should_receive(:full_messages).and_return([])
-        sale.should_receive(:state).and_return('pending')
-        sale.should_receive(:error).and_return(nil)
-        sale.should_receive(:errors).and_return(errors)
-        sale.should_receive(:save).and_return(true)
-        sale.should_receive(:guid).at_least(1).times.and_return('blah')
+        expect(errors).to receive(:full_messages).and_return([])
+        expect(sale).to receive(:state).and_return('pending')
+        expect(sale).to receive(:error).and_return(nil)
+        expect(sale).to receive(:errors).and_return(errors)
+        expect(sale).to receive(:save).and_return(true)
+        expect(sale).to receive(:guid).at_least(1).times.and_return('blah')
 
-        CreateSale.should_receive(:call).with(
+        expect(CreateSale).to receive(:call).with(
           'product_class' => 'product',
           'permalink' => @product.permalink,
           'controller' => 'payola/transactions',
@@ -30,7 +30,7 @@ module Payola
           'affiliate' => nil
         ).and_return(sale)
 
-        Payola.should_receive(:queue!)
+        expect(Payola).to receive(:queue!)
         post :create, product_class: @product.product_class, permalink: @product.permalink
 
         expect(response.status).to eq 200
@@ -41,16 +41,16 @@ module Payola
       describe "with an error" do
         it "should return an error in json" do
           sale = double
-          sale.should_receive(:error).and_return(nil)
-          sale.should_receive(:save).and_return(false)
-          sale.should_receive(:state).and_return('failed')
-          sale.should_receive(:guid).at_least(1).times.and_return('blah')
+          expect(sale).to receive(:error).and_return(nil)
+          expect(sale).to receive(:save).and_return(false)
+          expect(sale).to receive(:state).and_return('failed')
+          expect(sale).to receive(:guid).at_least(1).times.and_return('blah')
           error = double
-          error.should_receive(:full_messages).and_return(['done did broke'])
-          sale.should_receive(:errors).and_return(error)
+          expect(error).to receive(:full_messages).and_return(['done did broke'])
+          expect(sale).to receive(:errors).and_return(error)
 
-          CreateSale.should_receive(:call).and_return(sale)          
-          Payola.should_not_receive(:queue!)
+          expect(CreateSale).to receive(:call).and_return(sale)          
+          expect(Payola).to_not receive(:queue!)
 
           post :create, product_class: @product.product_class, permalink: @product.permalink
 

--- a/spec/models/payola/sale_spec.rb
+++ b/spec/models/payola/sale_spec.rb
@@ -40,7 +40,7 @@ module Payola
 
     describe "#process!" do
       it "should charge the card" do
-        Payola::ChargeCard.should_receive(:call)
+        expect(Payola::ChargeCard).to receive(:call)
 
         sale = create(:sale)
         sale.process!
@@ -50,8 +50,8 @@ module Payola
     describe "#finish" do
       it "should instrument finish" do
         sale = create(:sale, state: 'processing')
-        Payola.should_receive(:instrument).with('payola.product.sale.finished', sale)
-        Payola.should_receive(:instrument).with('payola.sale.finished', sale)
+        expect(Payola).to receive(:instrument).with('payola.product.sale.finished', sale)
+        expect(Payola).to receive(:instrument).with('payola.sale.finished', sale)
 
         sale.finish!
       end
@@ -60,8 +60,8 @@ module Payola
     describe "#fail" do
       it "should instrument fail" do
         sale = create(:sale, state: 'processing')
-        Payola.should_receive(:instrument).with('payola.product.sale.failed', sale)
-        Payola.should_receive(:instrument).with('payola.sale.failed', sale)
+        expect(Payola).to receive(:instrument).with('payola.product.sale.failed', sale)
+        expect(Payola).to receive(:instrument).with('payola.sale.failed', sale)
 
         sale.fail!
       end
@@ -70,8 +70,8 @@ module Payola
     describe "#refund" do
       it "should instrument refund" do
         sale = create(:sale, state: 'finished')
-        Payola.should_receive(:instrument).with('payola.product.sale.refunded', sale)
-        Payola.should_receive(:instrument).with('payola.sale.refunded', sale)
+        expect(Payola).to receive(:instrument).with('payola.product.sale.refunded', sale)
+        expect(Payola).to receive(:instrument).with('payola.sale.refunded', sale)
         sale.refund!
       end
     end

--- a/spec/payola_spec.rb
+++ b/spec/payola_spec.rb
@@ -25,15 +25,15 @@ module Payola
 
   describe "instrumentation" do
     it "should pass subscribe to StripeEvent" do
-      StripeEvent.should_receive(:subscribe)
+      expect(StripeEvent).to receive(:subscribe)
       Payola.subscribe('foo', 'blah')
     end
     it "should pass instrument to StripeEvent.backend" do
-      ActiveSupport::Notifications.should_receive(:instrument)
+      expect(ActiveSupport::Notifications).to receive(:instrument)
       Payola.instrument('foo', 'blah')
     end
     it "should pass all to StripeEvent" do
-      StripeEvent.should_receive(:all)
+      expect(StripeEvent).to receive(:all)
       Payola.all('blah')
     end
   end
@@ -48,7 +48,7 @@ module Payola
 
     describe "with symbol" do
       it "should find the correct background worker" do
-        FakeWorker.should_receive(:call)
+        expect(FakeWorker).to receive(:call)
 
         Payola.background_worker = :fake
         Payola.queue!('blah')
@@ -76,8 +76,8 @@ module Payola
 
     describe "with nothing" do
       it "should call autofind" do
-        FakeWorker.should_receive(:call).and_return(:true)
-        Payola::Worker.should_receive(:autofind).and_return(FakeWorker)
+        expect(FakeWorker).to receive(:call).and_return(:true)
+        expect(Payola::Worker).to receive(:autofind).and_return(FakeWorker)
         Payola.queue!('blah')
       end
     end
@@ -98,7 +98,7 @@ module Payola
         end
       end
 
-      FakeWorker.should_receive(:call).with(Payola::SendMail, 'Payola::FakeMailer', 'receipt', 1, 2)
+      expect(FakeWorker).to receive(:call).with(Payola::SendMail, 'Payola::FakeMailer', 'receipt', 1, 2)
       Payola.send_mail(FakeMailer, :receipt, 1, 2)
     end
   end
@@ -109,7 +109,7 @@ module Payola
     end
 
     it "should set up listeners for auto emails" do
-      Payola.should_receive(:subscribe).with('payola.sale.finished').at_least(2)
+      expect(Payola).to receive(:subscribe).with('payola.sale.finished').at_least(2)
       Payola.send_email_for :receipt, :admin_receipt
     end
   end

--- a/spec/services/payola/cancel_subscription_spec.rb
+++ b/spec/services/payola/cancel_subscription_spec.rb
@@ -17,7 +17,7 @@ module Payola
       it "should not change the state if an error occurs" do
         custom_error = StandardError.new("Customer not found")
         StripeMock.prepare_error(custom_error, :get_customer)
-        expect { CancelSubscription.call(@subscription) }.to raise_error
+        expect { CancelSubscription.call(@subscription) }.to raise_error("Customer not found")
         
         expect(@subscription.reload.state).to eq 'active'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ end
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'factory_girl_rails'
 require 'stripe_mock'
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -49,7 +49,7 @@ module Payola
 
     describe "#call" do
       it "should call perform_async" do
-        Payola::Worker::Sidekiq.should_receive(:perform_async)
+        expect(Payola::Worker::Sidekiq).to receive(:perform_async)
         Payola::Worker::Sidekiq.call(Payola::TestService, double)
       end
     end
@@ -88,7 +88,7 @@ module Payola
 
     describe "#call" do
       it "should call perform_later" do
-        Payola::Worker::ActiveJob.should_receive(:perform_later)
+        expect(Payola::Worker::ActiveJob).to receive(:perform_later)
         Payola::Worker::ActiveJob.call(Payola::TestService, double)
       end
     end


### PR DESCRIPTION
This PR fixes the following warnings from RSpec:

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<StandardError: Customer not found>. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /payola/spec/services/payola/cancel_subscription_spec.rb:20:in `block (3 levels) in <module:Payola>'.
```

```
Deprecation Warnings:

Requiring `rspec/autorun` when running RSpec via the `rspec` command is deprecated. Called from /Users/Jake/.rvm/gems/ruby-2.1.5/gems/activesupport-4.2.5/lib/active_support/dependencies.rb:274:in `require'.

Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /payola/spec/controllers/payola/subscriptions_controller_spec.rb:103:in `block (3 levels) in <module:Payola>'.
```