### PR TITLE
Convert tax_percent from integer to decimal (at most two decimal places)

### DIFF
--- a/app/views/payola/subscriptions/_checkout.html.erb
+++ b/app/views/payola/subscriptions/_checkout.html.erb
@@ -27,7 +27,7 @@
   form_id = "#{button_id}-form"
 
   currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
-  tax_percent = local_assigns.fetch(:tax_percent, Payola.default_tax_percent).to_i
+  tax_percent = local_assigns.fetch(:tax_percent, Payola.default_tax_percent).to_f.round(2)
   stripe_customer_id = local_assigns.fetch(:stripe_customer_id, nil)
 
   error_div_id = local_assigns.fetch :error_div_id, ''

--- a/db/migrate/20151205004838_change_tax_percent_format_in_payola_subscriptions.rb
+++ b/db/migrate/20151205004838_change_tax_percent_format_in_payola_subscriptions.rb
@@ -1,0 +1,5 @@
+class ChangeTaxPercentFormatInPayolaSubscriptions < ActiveRecord::Migration
+  def change
+    change_column :payola_subscriptions, :tax_percent, :decimal, :precision => 4, :scale => 2
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151003120400) do
+ActiveRecord::Schema.define(version: 20151205004838) do
 
   create_table "owners", force: :cascade do |t|
     t.datetime "created_at"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 20151003120400) do
     t.text     "customer_address"
     t.text     "business_address"
     t.integer  "setup_fee"
-    t.decimal  "tax_percent"
+    t.decimal  "tax_percent",                      precision: 4, scale: 2
   end
 
   add_index "payola_subscriptions", ["guid"], name: "index_payola_subscriptions_on_guid"


### PR DESCRIPTION
Minor fix to change `tax_percent` from integer to decimal. Up to two decimal places as per Stripe's API documentation:

```
A positive decimal (with at most two decimal places) between 1 and 100.
This represents the percentage of the subscription invoice subtotal that will
be calculated and added as tax to the final amount each billing period. 
```