### PR TITLE
StartSubscription not longer requires StripeToken for free plans

### DIFF
--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -51,7 +51,7 @@ module Payola
             card_type:           card.respond_to?(:brand) ? card.brand : card.type,
           )
         end
-        
+
         subscription.activate!
       rescue Stripe::StripeError, RuntimeError => e
         subscription.update_attributes(error: e.message)
@@ -76,8 +76,8 @@ module Payola
         return customer unless customer.try(:deleted)
       end
 
-      unless subscription.stripe_token.present?
-        raise "stripeToken required for new customer subscription"
+      if subscription.plan.amount > 0 and not subscription.stripe_token.present?
+        raise "stripeToken required for new customer with paid subscription"
       end
 
       customer_create_params = {

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 20150930164135) do
     t.text     "customer_address"
     t.text     "business_address"
     t.integer  "setup_fee"
-    t.integer  "tax_percent"
+    t.decimal  "tax_percent"
   end
 
   add_index "payola_subscriptions", ["guid"], name: "index_payola_subscriptions_on_guid"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151003120400) do
+ActiveRecord::Schema.define(version: 20150930164135) do
 
   create_table "owners", force: :cascade do |t|
     t.datetime "created_at"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 20151003120400) do
     t.text     "customer_address"
     t.text     "business_address"
     t.integer  "setup_fee"
-    t.decimal  "tax_percent"
+    t.integer  "tax_percent"
   end
 
   add_index "payola_subscriptions", ["guid"], name: "index_payola_subscriptions_on_guid"

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -13,6 +13,12 @@ module Payola
         StartSubscription.call(subscription)
         expect(subscription.reload.stripe_customer_id).to_not be_nil
       end
+      it "should create a customer with free plan without stripe_token" do
+        plan = create(:subscription_plan, amount:0)
+        subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: nil)
+        StartSubscription.call(subscription)
+        expect(subscription.reload.stripe_customer_id).to_not be_nil
+      end
       it "should capture credit card info" do
         plan = create(:subscription_plan)
         subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: token)
@@ -48,7 +54,7 @@ module Payola
         subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: nil, stripe_customer_id: stripe_customer.id)
         expect(subscription).to receive(:fail!)
         StartSubscription.call(subscription)
-        expect(subscription.reload.error).to eq "stripeToken required for new customer subscription"
+        expect(subscription.reload.error).to eq "stripeToken required for new customer with paid subscription"
       end
 
       it "should re-use an existing customer" do
@@ -73,7 +79,7 @@ module Payola
         subscription2 = create(:subscription, state: 'processing', plan: plan, stripe_token: nil, owner: user)
         expect(subscription2).to receive(:fail!)
         StartSubscription.call(subscription2)
-        expect(subscription2.reload.error).to eq "stripeToken required for new customer subscription"
+        expect(subscription2.reload.error).to eq "stripeToken required for new customer with paid subscription"
       end
 
       it "should create an invoice item with a setup fee" do


### PR DESCRIPTION
A minor fix to avoid the requirement of the StripeToken on StartSubscription for free plans (plans with amount == 0)