### PR TITLE
Update cancel_at_period_end in CancelSubscription service

### DIFF
--- a/app/services/payola/cancel_subscription.rb
+++ b/app/services/payola/cancel_subscription.rb
@@ -4,13 +4,15 @@ module Payola
       secret_key = Payola.secret_key_for_sale(subscription)
       Stripe.api_key = secret_key
       customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
-      customer.subscriptions.retrieve(subscription.stripe_id,secret_key).delete(options,secret_key)
+      customer.subscriptions.retrieve(subscription.stripe_id, secret_key).delete(options, secret_key)
       
-      unless options[:at_period_end] == true
+      if options[:at_period_end] == true
+        # Store that the subscription will be canceled at the end of the billing period
+        subscription.update_attributes(cancel_at_period_end: true)
+      else
+        # Cancel the subscription immediately
         subscription.cancel!
       end
     end
-
   end
 end
-


### PR DESCRIPTION
If `CancelSubscription` is called with `at_period_end: true`, also update the subscription to store that it will be canceled at the end of the billing period.

Previously, this attribute wouldn't be changed until the Payola subscription was synced with the associated Stripe subscription (ie. when a webhook arrived).

Also, add a test to assert that the Payola subscription isn't immediately canceled if the `at_period_end: true` option is used.