### PR TITLE
Stop setting Stripe.api_key directly in CancelSubscription service

### DIFF
--- a/app/services/payola/cancel_subscription.rb
+++ b/app/services/payola/cancel_subscription.rb
@@ -2,7 +2,6 @@ module Payola
   class CancelSubscription
     def self.call(subscription, options = {})
       secret_key = Payola.secret_key_for_sale(subscription)
-      Stripe.api_key = secret_key
       customer = Stripe::Customer.retrieve(subscription.stripe_customer_id, secret_key)
       customer.subscriptions.retrieve(subscription.stripe_id,secret_key).delete(options,secret_key)
       


### PR DESCRIPTION
I think this was probably accidentally committed while developing.

We don't want to set `Stripe.api_key` directly as this has global consequences. Use the pattern we use everywhere else of explicitly passing the API key to each API call.

Note that we are already explicitly passing the API key to our Stripe API calls in `CancelSubscription`.