### PR TITLE
Update subscription amount

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -101,6 +101,8 @@ module Payola
       self.canceled_at          = Time.at(stripe_sub.canceled_at) if stripe_sub.canceled_at
       self.quantity             = stripe_sub.quantity
       self.stripe_status        = stripe_sub.status
+      self.amount               = stripe_sub.plan.amount
+      self.currency             = stripe_sub.plan.respond_to?(:currency) ? stripe_sub.plan.currency : Payola.default_currency
       self.cancel_at_period_end = stripe_sub.cancel_at_period_end
 
       self.save!

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -29,7 +29,7 @@ module Payola
         subscription = build(:subscription, stripe_token: nil)
         expect(subscription.valid?).to be true
       end
-      
+
       it "should validate nil stripe_token when the subscription owner is present" do
         plan = create(:subscription_plan)
         plan.amount = 0
@@ -85,8 +85,8 @@ module Payola
       end
 
       it "should sync non-timestamp fields" do
-        plan = create(:subscription_plan)
-        subscription = build(:subscription, plan: plan)
+        plan = create(:subscription_plan, amount: 200)
+        subscription = build(:subscription, plan: plan, amount: 50)
         stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
 
         expect(stripe_sub).to receive(:quantity).and_return(10).at_least(1)
@@ -97,6 +97,7 @@ module Payola
         subscription.reload
 
         expect(subscription.quantity).to eq 10
+        expect(subscription.amount).to eq 200
         expect(subscription.stripe_status).to eq 'active'
         expect(subscription.cancel_at_period_end).to eq true
       end


### PR DESCRIPTION
Payola `Subscription` stores plan [amount](https://github.com/peterkeen/payola/blob/879d078c98b0ce78e449fcfde7810add8af5f1e2/app/services/payola/create_subscription.rb#L29) & [currency](https://github.com/peterkeen/payola/blob/879d078c98b0ce78e449fcfde7810add8af5f1e2/app/services/payola/create_subscription.rb#L19) at creation by not [during update](https://github.com/peterkeen/payola/blob/879d078c98b0ce78e449fcfde7810add8af5f1e2/app/models/payola/subscription.rb#L96-L104).

This PR aims to synchronize `amount` & `currency` fields with Stripe subscription