### PR TITLE
Send the plan_id along with the form submission

### DIFF
--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -39,6 +39,7 @@ var PayolaSubscriptionCheckout = {
         var form = $("#" + options.form_id);
         form.append($('<input type="hidden" name="stripeToken">').val(token.id));
         form.append($('<input type="hidden" name="stripeEmail">').val(token.email));
+        form.append($('<input type="hidden" name="plan_id">').val(options.plan_id));
         form.append($('<input type="hidden" name="quantity">').val(options.quantity));
         form.append($('<input type="hidden" name="coupon">').val(options.coupon));
         form.append($('<input type="hidden" name="tax_percent">').val(options.tax_percent));


### PR DESCRIPTION
If I am overriding the [`form_url` in my `local_assigns`](https://github.com/peterkeen/payola/blob/fc613a41cfa61f2157a35305884f1dc59e5f9ba8/app/views/payola/subscriptions/_checkout.html.erb#L20) with a URL that isn't RESTful for plans, there is no way to know to which `Plan` the User is subscribing.

Adding the `plan_id` here doesn't hurt anything but may certainly come in handy for some others who might face this situation.