### PR TITLE
Submit all subscription options for existing stripe customers

### DIFF
--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -12,7 +12,12 @@ var PayolaSubscriptionCheckout = {
 
         if (options.stripe_customer_id) {
           // If an existing Stripe customer id is specified, don't open the Stripe Checkout - just AJAX submit the form
-          PayolaSubscriptionCheckout.submitForm(form.attr('action'), { stripe_customer_id: options.stripe_customer_id }, options);
+          PayolaSubscriptionCheckout.submitForm(form.attr('action'), {
+            stripe_customer_id: options.stripe_customer_id,
+            coupon: options.coupon,
+            tax_percent: options.tax_percent,
+            signed_custom_fields: options.signed_custom_fields || undefined
+          }, options);
         } else {
           // Open a Stripe Checkout to collect the customer's billing details
           var handler = StripeCheckout.configure({


### PR DESCRIPTION
Previously the subscription options `coupon`, `tax_percent` and
`signed_custom_fields` were only added to the submitted form in the
Stripe token callback. If an existing Stripe custmer id was given these
options were ignored, meaning that a customer could not resubscribe
using a coupon code, for example.