### PR TITLE
Set a customer's payment source if nil

### DIFF
--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -73,7 +73,15 @@ module Payola
       if stripe_customer_id
         # Retrieve the customer from Stripe and use it for this subscription
         customer = Stripe::Customer.retrieve(stripe_customer_id, secret_key)
-        return customer unless customer.try(:deleted)
+
+        unless customer.try(:deleted)
+          if customer.default_source.nil? && subscription.stripe_token.present?
+            customer.source = subscription.stripe_token
+            customer.save
+          end
+
+          return customer
+        end
       end
 
       if subscription.plan.amount > 0 and not subscription.stripe_token.present?

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -71,7 +71,7 @@ module Payola
 
       it "should assign a passed payment source to an existing customer without one" do
         plan = create(:subscription_plan, amount:0)
-        subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: nil)
+        subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: nil, owner: user)
         StartSubscription.call(subscription)
         expect(Stripe::Customer.retrieve(subscription.reload.stripe_customer_id).default_source).to be_nil
 

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -69,6 +69,21 @@ module Payola
         expect(subscription2.reload.stripe_customer_id).to eq subscription.reload.stripe_customer_id
       end
 
+      it "should assign a passed payment source to an existing customer without one" do
+        plan = create(:subscription_plan, amount:0)
+        subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: nil)
+        StartSubscription.call(subscription)
+        expect(Stripe::Customer.retrieve(stripe_customer_id).default_source).to be_nil
+
+        plan2 = create(:subscription_plan)
+        subscription2 = create(:subscription, state: 'processing', plan: plan2, stripe_token: token, owner: user)
+        StartSubscription.call(subscription2)
+
+        stripe_customer_id = subscription2.reload.stripe_customer_id
+        expect(stripe_customer_id).to eq subscription.reload.stripe_customer_id
+        expect(Stripe::Customer.retrieve(stripe_customer_id).default_source).to_not be_nil
+      end
+
       it "should not re-use an existing customer that has been deleted" do
         plan = create(:subscription_plan)
         subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: token, owner: user)

--- a/spec/services/payola/start_subscription_spec.rb
+++ b/spec/services/payola/start_subscription_spec.rb
@@ -73,7 +73,7 @@ module Payola
         plan = create(:subscription_plan, amount:0)
         subscription = create(:subscription, state: 'processing', plan: plan, stripe_token: nil)
         StartSubscription.call(subscription)
-        expect(Stripe::Customer.retrieve(stripe_customer_id).default_source).to be_nil
+        expect(Stripe::Customer.retrieve(subscription.reload.stripe_customer_id).default_source).to be_nil
 
         plan2 = create(:subscription_plan)
         subscription2 = create(:subscription, state: 'processing', plan: plan2, stripe_token: token, owner: user)


### PR DESCRIPTION
Since a free `Payola::Subscription` can be subscribed to without a customer payment source (`stripeToken`), any subsequent subscriptions will attempt to re-use the newly created `stripe_customer_id` that doesn't have a payment source associated with it (even if the customer has entered their CC info during the second subscription checkout phase.)

If we have an available `stripeToken` to use and the customer doesn't have a default payment source, it makes sense to assign it to the customer which will allow the transaction to succeed.