### PR TITLE
Maintain the active coupon code on a subscription

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -103,6 +103,9 @@ module Payola
       self.stripe_status        = stripe_sub.status
       self.cancel_at_period_end = stripe_sub.cancel_at_period_end
 
+      # Support for discounts is added to stripe-ruby-mock in v2.2.0, 84f08eb
+      self.coupon               = stripe_sub.discount && stripe_sub.discount.coupon.id if stripe_sub.respond_to?(:discount)
+
       self.save!
       self
     end

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -65,6 +65,7 @@ module Payola
         plan = create(:subscription_plan)
         subscription = build(:subscription, plan: plan)
         stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
+
         old_start = subscription.current_period_start
         old_end = subscription.current_period_end
         trial_start = subscription.trial_start
@@ -87,7 +88,9 @@ module Payola
       it "should sync non-timestamp fields" do
         plan = create(:subscription_plan)
         subscription = build(:subscription, plan: plan)
-        stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))
+        coupon = create(:payola_coupon)
+        stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1), coupon: coupon.code)
+        stripe_sub.stub_chain(:discount, :coupon, :id).and_return(coupon.code)
 
         expect(stripe_sub).to receive(:quantity).and_return(10).at_least(1)
         expect(stripe_sub).to receive(:cancel_at_period_end).and_return(true).at_least(1)
@@ -99,6 +102,7 @@ module Payola
         expect(subscription.quantity).to eq 10
         expect(subscription.stripe_status).to eq 'active'
         expect(subscription.cancel_at_period_end).to eq true
+        expect(subscription.coupon).to eq coupon.code
       end
     end
   end


### PR DESCRIPTION
Stripe removes coupon codes from a subscription after their repeating
duration has elapsed. When this happens, or when the subscription is
changed for any other reason, we want to update the coupon store on the
Payola subscription.

We need to check whether the stripe_sub will `respond_to?(:discount)`
before attempting to copy the value because this attribute is added to
stripe-ruby-mock in version 2.2.0.