### PR TITLE
unpegged stripe from 1.20.1

### DIFF
--- a/payola.gemspec
+++ b/payola.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.1"
   s.add_dependency "jquery-rails"
-  s.add_dependency "stripe", "= 1.20.1"
+  s.add_dependency "stripe"
   s.add_dependency "aasm", ">= 4.0.7"
   s.add_dependency "stripe_event", ">= 1.3.0"
 


### PR DESCRIPTION
Sends stripe to 1.4.0 and let's us modern stripe methods

Tested subscriptions still working and connect