### PR TITLE
Build out Payola coupon management

### DIFF
--- a/app/controllers/payola/coupons_controller.rb
+++ b/app/controllers/payola/coupons_controller.rb
@@ -1,0 +1,56 @@
+module Payola
+  class CouponsController < ApplicationController
+    before_filter :check_modify_permissions, only: [:create, :destroy]
+
+    def create
+      @coupon = Coupon.new(coupon_params)
+
+      if @coupon.save
+        redirect_to return_to, notice: "Succesfully created new coupon"
+      else
+        redirect_to return_to, alert: "Could not create new coupon"
+      end  
+    end
+
+    def destroy
+      @coupon = Coupon.find(params[:id])
+
+      if @coupon.destroy
+        redirect_to return_to, notice: "Succesfully removed the coupon"
+      else
+        redirect_to return_to, alert: "Could not remove the coupon"
+      end  
+    end
+
+    private
+
+    def check_modify_permissions
+      if self.respond_to?(:payola_can_modify_coupon?)
+        redirect_to(
+          return_to,
+          alert: "You cannot modify this coupon."
+        ) and return unless self.payola_can_modify_coupon?(params[:id])
+      end
+    end
+
+    def coupon_params
+      params.require(:coupon)
+        .permit(
+          :id,
+          :code,
+          :active,
+          :percent_off,
+          :amount_off,
+          :duration,
+          :duration_in_months,
+          :max_redemptions,
+          :redeem_by,
+          :currency
+        )
+    end
+
+    def return_to
+      params[:return_to] || :back
+    end
+  end
+end

--- a/app/models/payola/coupon.rb
+++ b/app/models/payola/coupon.rb
@@ -2,6 +2,7 @@ module Payola
   class Coupon < ActiveRecord::Base
     validates_uniqueness_of :code
     validates_presence_of :duration
+    validates :percent_off, numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 }
 
     before_create  :create_stripe_coupon,  if: -> { Payola.create_stripe_coupons }
     before_destroy :destroy_stripe_coupon, if: -> { Payola.create_stripe_coupons }

--- a/app/models/payola/coupon.rb
+++ b/app/models/payola/coupon.rb
@@ -2,7 +2,19 @@ module Payola
   class Coupon < ActiveRecord::Base
     validates_uniqueness_of :code
     validates_presence_of :duration
-    validates :percent_off, numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 }
+
+    validates_numericality_of :amount_off, allow_blank: true
+    validates_numericality_of :percent_off, allow_blank: true, greater_than: 0, less_than_or_equal_to: 100
+
+    validate :amount_xor_percent
+
+  private
+
+    def amount_xor_percent
+      unless amount_off.blank? ^ percent_off.blank?
+        errors.add(:base, "Specify an amount off or a percent off, not both")
+      end
+    end
 
     before_create  :create_stripe_coupon,  if: -> { Payola.create_stripe_coupons }
     before_destroy :destroy_stripe_coupon, if: -> { Payola.create_stripe_coupons }

--- a/app/models/payola/coupon.rb
+++ b/app/models/payola/coupon.rb
@@ -2,5 +2,11 @@ module Payola
   class Coupon < ActiveRecord::Base
     validates_uniqueness_of :code
     validates_presence_of :duration
+
+    before_create  :create_stripe_coupon,  if: -> { Payola.create_stripe_coupons }
+
+    def create_stripe_coupon
+      Payola::CreateCoupon.call(self)
+    end
   end
 end

--- a/app/models/payola/coupon.rb
+++ b/app/models/payola/coupon.rb
@@ -1,5 +1,6 @@
 module Payola
   class Coupon < ActiveRecord::Base
     validates_uniqueness_of :code
+    validates_presence_of :duration
   end
 end

--- a/app/models/payola/coupon.rb
+++ b/app/models/payola/coupon.rb
@@ -4,9 +4,14 @@ module Payola
     validates_presence_of :duration
 
     before_create  :create_stripe_coupon,  if: -> { Payola.create_stripe_coupons }
+    before_destroy :destroy_stripe_coupon, if: -> { Payola.create_stripe_coupons }
 
     def create_stripe_coupon
       Payola::CreateCoupon.call(self)
+    end
+
+    def destroy_stripe_coupon
+      Payola::DestroyCoupon.call(self.code)
     end
   end
 end

--- a/app/services/payola/create_coupon.rb
+++ b/app/services/payola/create_coupon.rb
@@ -1,0 +1,37 @@
+module Payola
+  class CreateCoupon
+    def self.call(params)
+      secret_key = Payola.secret_key
+
+      code               = params[:code]
+      duration           = params[:duration]
+      max_redemptions    = params[:max_redemptions]
+      redeem_by          = params[:redeem_by]
+      currency           = params[:currency].present?  ? params[:currency] : Payola.default_currency
+
+      if duration == 'repeating'
+        duration_in_months = params[:duration_in_months]
+      else
+        duration_in_months = nil
+      end
+
+      begin
+        return Stripe::Coupon.retrieve(code)
+      rescue Stripe::InvalidRequestError
+        # fall through
+      end
+
+      Stripe::Coupon.create({
+        id: code,
+        duration: duration,
+        duration_in_months: duration_in_months,
+        max_redemptions: max_redemptions,
+        amount_off:  params[:amount_off].presence,
+        percent_off: params[:percent_off].presence,
+        currency:  currency,
+        redeem_by: redeem_by,
+        metadata:  params[:metadata].presence
+      }, secret_key)
+    end
+  end
+end

--- a/app/services/payola/create_coupon.rb
+++ b/app/services/payola/create_coupon.rb
@@ -16,7 +16,7 @@ module Payola
       end
 
       begin
-        return Stripe::Coupon.retrieve(code)
+        return Stripe::Coupon.retrieve(code, secret_key)
       rescue Stripe::InvalidRequestError
         # fall through
       end

--- a/app/services/payola/create_coupon.rb
+++ b/app/services/payola/create_coupon.rb
@@ -29,7 +29,7 @@ module Payola
         amount_off:  params[:amount_off].presence,
         percent_off: params[:percent_off].presence,
         currency:  currency,
-        redeem_by: redeem_by,
+        redeem_by: redeem_by.to_i,
         metadata:  params[:metadata].presence
       }, secret_key)
     end

--- a/app/services/payola/destroy_coupon.rb
+++ b/app/services/payola/destroy_coupon.rb
@@ -1,0 +1,8 @@
+module Payola
+  class DestroyCoupon
+    def self.call(code)
+      secret_key = Payola.secret_key
+      Stripe::Coupon.retrieve(code, secret_key).delete
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Payola::Engine.routes.draw do
 
   match '/create_card/:customer_id'       => 'cards#create', via: :post, as: :create_card
   match '/destroy_card/:id/:customer_id'  => 'cards#destroy', via: :delete, as: :destroy_card
+
+  match '/create_coupon'       => 'coupons#create', via: :post, as: :create_coupon
+  match '/destroy_coupon/:id'  => 'coupons#destroy', via: :delete, as: :destroy_coupon
   
   mount StripeEvent::Engine => '/events'
 end

--- a/db/migrate/20160429161549_add_fields_to_coupons.rb
+++ b/db/migrate/20160429161549_add_fields_to_coupons.rb
@@ -1,0 +1,10 @@
+class AddFieldsToCoupons < ActiveRecord::Migration
+  def change
+    add_column :payola_coupons, :amount_off, :integer, default: true
+    add_column :payola_coupons, :duration, :string, default: 'once'
+    add_column :payola_coupons, :duration_in_months, :integer
+    add_column :payola_coupons, :max_redemptions, :integer
+    add_column :payola_coupons, :redeem_by, :timestamp
+    add_column :payola_coupons, :currency, :string
+  end
+end

--- a/db/migrate/20160429161549_add_fields_to_coupons.rb
+++ b/db/migrate/20160429161549_add_fields_to_coupons.rb
@@ -1,6 +1,6 @@
 class AddFieldsToCoupons < ActiveRecord::Migration
   def change
-    add_column :payola_coupons, :amount_off, :integer, default: true
+    add_column :payola_coupons, :amount_off, :integer
     add_column :payola_coupons, :duration, :string, default: 'once'
     add_column :payola_coupons, :duration_in_months, :integer
     add_column :payola_coupons, :max_redemptions, :integer

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -31,7 +31,8 @@ module Payola
       :additional_charge_attributes,
       :guid_generator,
       :pdf_receipt,
-      :create_stripe_plans
+      :create_stripe_plans,
+      :create_stripe_coupons
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?
@@ -92,6 +93,7 @@ module Payola
       self.pdf_receipt = false
       self.guid_generator = lambda { SecureRandom.random_number(1_000_000_000).to_s(32) }
       self.create_stripe_plans = true
+      self.create_stripe_coupons = true
     end
 
     def register_sellable(klass)

--- a/spec/controllers/payola/coupons_controller_spec.rb
+++ b/spec/controllers/payola/coupons_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+module Payola
+  describe CouponsController do
+    routes { Payola::Engine.routes }
+  
+    before do
+      Payola.secret_key = 'sk_test_12345'
+      Payola.create_stripe_coupons = false
+      request.env["HTTP_REFERER"] = "/my/coupons"
+    end
+
+    describe '#create' do
+
+      it "creates a coupon" do
+        expect(CreateCoupon).not_to receive(:call)
+        post :create, coupon: { code: 'savings', duration: 'once', amount_off: 10 }
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/coupons"
+        expect(flash[:notice]).to eq "Succesfully created new coupon"
+        expect(flash[:alert]).to_not be_present
+      end
+
+      it "passes args to CreateCoupon" do
+        Payola.create_stripe_coupons = true
+
+        expect(CreateCoupon).to receive(:call)
+        post :create, coupon: { code: 'savings', duration: 'once', amount_off: 10 }
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/coupons"
+        expect(flash[:notice]).to eq "Succesfully created new coupon"
+        expect(flash[:alert]).to_not be_present
+      end
+
+      it "returns to the passed return path" do
+        post :create, coupon: { code: 'savings', duration: 'once', amount_off: 10 }, return_to: "/another/path"
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/another/path"
+      end
+    end
+
+    describe '#destroy' do
+
+      let(:coupon) { create :payola_coupon }
+
+      it "destroys the coupon" do
+        expect(DestroyCoupon).not_to receive(:call)
+        delete :destroy, id: coupon.id
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/coupons"
+        expect(flash[:notice]).to eq "Succesfully removed the coupon"
+        expect(flash[:alert]).to_not be_present
+      end
+
+      it "passes args to DestroyCoupon" do
+        Payola.create_stripe_coupons = true
+
+        expect(DestroyCoupon).to receive(:call)
+        delete :destroy, id: coupon.id
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/my/coupons"
+        expect(flash[:notice]).to eq "Succesfully removed the coupon"
+        expect(flash[:alert]).to_not be_present
+      end
+
+      it "should return to the passed return path" do
+        delete :destroy, id: coupon.id, return_to: "/another/path"
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to "/another/path"
+      end
+    end
+
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20160429161549) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "active",             default: true
-    t.integer  "amount_off",         default: 1
+    t.integer  "amount_off"
     t.string   "duration",           default: "once"
     t.integer  "duration_in_months"
     t.integer  "max_redemptions"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151205004838) do
+ActiveRecord::Schema.define(version: 20160429161549) do
+
   create_table "owners", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -30,7 +31,13 @@ ActiveRecord::Schema.define(version: 20151205004838) do
     t.integer  "percent_off"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "active",      default: true
+    t.boolean  "active",             default: true
+    t.integer  "amount_off",         default: 1
+    t.string   "duration",           default: "once"
+    t.integer  "duration_in_months"
+    t.integer  "max_redemptions"
+    t.datetime "redeem_by"
+    t.string   "currency"
   end
 
   create_table "payola_sales", force: :cascade do |t|

--- a/spec/factories/payola_coupons.rb
+++ b/spec/factories/payola_coupons.rb
@@ -4,5 +4,28 @@ FactoryGirl.define do
   factory :payola_coupon, :class => 'Payola::Coupon' do
     code "MyString"
     percent_off 1
+
+    duration 'once'
+    max_redemptions 1
+    redeem_by 1.day.from_now
+
+    trait :flat_amount do
+      percent_off nil
+      amount_off 2
+      currency 'USD'
+    end
+
+    trait :repeating do
+      duration 'repeating'
+      duration_in_months 1
+    end
+
+    trait :perpetual do
+      duration 'forever'
+    end
+
+    trait :expired do
+      redeem_by 1.day.ago
+    end
   end
 end

--- a/spec/models/payola/coupon_spec.rb
+++ b/spec/models/payola/coupon_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 module Payola
   describe Coupon do
+
+    before { Payola.create_stripe_coupons = false }
+
     describe "validations" do
       it "should validate uniqueness of coupon code" do
         c1 = Coupon.create(code: 'abc')

--- a/spec/models/payola/coupon_spec.rb
+++ b/spec/models/payola/coupon_spec.rb
@@ -26,5 +26,45 @@ module Payola
         expect(c1.active?).to be_truthy
       end
     end
+
+    context "with Payola.create_stripe_coupons set to false" do
+
+      it "should not try to create the coupon at stripe before the model is created" do
+        coupon = build(:payola_coupon)
+        expect(Payola::CreateCoupon).to_not receive(:call)
+        coupon.save!
+      end
+
+      it "should not try to create the coupon at stripe before the model is updated" do
+        coupon = build(:payola_coupon)
+        coupon.save!
+        coupon.redeem_by = 1.week.from_now
+
+        expect(Payola::CreateCoupon).to_not receive(:call)
+        coupon.save!
+      end
+    end
+
+    context "with Payola.create_stripe_coupons set to true" do
+      before do
+        Payola.create_stripe_coupons = true
+        Payola.secret_key = 'sk_test_12345'
+      end
+
+      it "should create the coupon at stripe before the model is created" do
+        coupon = build(:payola_coupon)
+        expect(Payola::CreateCoupon).to receive(:call)
+        coupon.save!
+      end
+
+      it "should not try to create the coupon at stripe before the model is updated" do
+        coupon = build(:payola_coupon)
+        coupon.save!
+        coupon.redeem_by = 1.week.from_now
+
+        expect(Payola::CreateCoupon).to_not receive(:call)
+        coupon.save!
+      end
+    end
   end
 end

--- a/spec/models/payola/coupon_spec.rb
+++ b/spec/models/payola/coupon_spec.rb
@@ -24,6 +24,17 @@ module Payola
         c3 = build(:payola_coupon, percent_off: 101)
         expect(c3.valid?).to be_falsey
       end
+
+      it "allows percentage off or amount off, but not both" do
+        c1 = build(:payola_coupon, percent_off: 60)
+        expect(c1.valid?).to be_truthy
+
+        c2 = build(:payola_coupon, :flat_amount)
+        expect(c2.valid?).to be_truthy
+
+        c3 = build(:payola_coupon, percent_off: 60, amount_off: 20)
+        expect(c3.valid?).to be_falsey
+      end
     end
 
     describe "active" do

--- a/spec/models/payola/coupon_spec.rb
+++ b/spec/models/payola/coupon_spec.rb
@@ -7,10 +7,10 @@ module Payola
 
     describe "validations" do
       it "should validate uniqueness of coupon code" do
-        c1 = Coupon.create(code: 'abc')
+        c1 = create(:payola_coupon, code: 'abc')
         expect(c1.valid?).to be_truthy
 
-        c2 = Coupon.new(code: 'abc')
+        c2 = build(:payola_coupon, code: 'abc')
         expect(c2.valid?).to be_falsey
       end
 

--- a/spec/models/payola/coupon_spec.rb
+++ b/spec/models/payola/coupon_spec.rb
@@ -13,6 +13,17 @@ module Payola
         c2 = Coupon.new(code: 'abc')
         expect(c2.valid?).to be_falsey
       end
+
+      it "validates percent_off is between 1 and 100" do
+        c1 = create(:payola_coupon, percent_off: 60)
+        expect(c1.valid?).to be_truthy
+
+        c2 = build(:payola_coupon, percent_off: 0)
+        expect(c2.valid?).to be_falsey
+
+        c3 = build(:payola_coupon, percent_off: 101)
+        expect(c3.valid?).to be_falsey
+      end
     end
 
     describe "active" do

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -86,6 +86,8 @@ module Payola
       end
 
       it "should sync non-timestamp fields" do
+        Payola.create_stripe_coupons = false
+
         plan = create(:subscription_plan, amount: 200)
         subscription = build(:subscription, plan: plan, amount: 50)
         stripe_sub = Stripe::Customer.create.subscriptions.create(plan: plan.stripe_id, source: StripeMock.generate_card_token(last4: '1234', exp_year: Time.now.year + 1))

--- a/spec/payola_spec.rb
+++ b/spec/payola_spec.rb
@@ -142,4 +142,11 @@ module Payola
       expect(Payola.create_stripe_plans).to be true
     end
   end
+
+  describe "#create_stripe_coupons" do
+    it "defaults to true" do
+      Payola.reset!
+      expect(Payola.create_stripe_coupons).to be true
+    end
+  end
 end

--- a/spec/services/payola/create_coupon_spec.rb
+++ b/spec/services/payola/create_coupon_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module Payola
+  describe CreateCoupon do
+  
+    let(:coupon) { create(:payola_coupon) }
+
+    before do
+      Payola.secret_key = 'sk_test_12345'
+    end
+
+    describe "#call" do
+      it "creates a coupon" do
+        @coupon = CreateCoupon.call(
+          percent_off: 25,
+          duration: 'repeating',
+          duration_in_months: 3,
+          code: '25OFF'
+        )
+
+        expect(@coupon.id).to eq '25OFF'
+        expect(@coupon.percent_off).to eq 25
+        expect(@coupon.duration).to eq 'repeating'
+        expect(@coupon.duration_in_months).to eq 3
+      end     
+    end
+  end
+end

--- a/spec/services/payola/create_sale_spec.rb
+++ b/spec/services/payola/create_sale_spec.rb
@@ -35,6 +35,8 @@ module Payola
       end
 
       describe "with coupon" do
+        before { Payola.create_stripe_coupons = false }
+
         it "should include the coupon" do
           coupon = create(:payola_coupon)
 

--- a/spec/services/payola/destroy_coupon_spec.rb
+++ b/spec/services/payola/destroy_coupon_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Payola
+  describe DestroyCoupon do
+  
+    before do
+      Payola.secret_key = 'sk_test_12345'
+
+      @coupon = Stripe::Coupon.create({
+        percent_off: 25,
+        duration: 'repeating',
+        duration_in_months: 3,
+        id: '25OFF'
+      })
+    end
+
+    describe "#call" do
+      it "destroys the coupon" do
+        expect{ Payola::DestroyCoupon.call(@coupon.id) }.to_not raise_error
+        expect{ Stripe::Coupon.retrieve(@coupon.id, Payola.secret_key) }.to raise_error(Stripe::InvalidRequestError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows Payola to create and destroy coupons over on Stripe with all of the other features that Stripe coupons offer. This now includes:

<table>
  <tr>
    <td>Key</td>
    <td>Description</td>
  </tr>
  <tr>
    <td>`duration`</td>
    <td>(REQUIRED) Specifies how long the discount will be in effect. Can be `forever`, `once`, or `repeating`.</td>
  </tr>
  <tr>
    <td>`duration_in_months`</td>
    <td>Required only if `duration` is `repeating`, in which case it must be a positive integer that specifies the number of months the discount will be in effect.</td>
  </tr>
  <tr>
    <td>`percent_off`</td>
    <td>A positive integer between 1 and 100 that represents the discount the coupon will apply (required if `amount_off` is not passed)</td>
  </tr>
  <tr>
    <td>`amount_off`</td>
    <td>A positive integer representing the amount to subtract from an invoice total (required if `percent_off` is not passed)</td>
  </tr>
  <tr>
    <td>`currency`</td>
    <td>Currency of the amount_off parameter (required if `amount_off` is passed)</td>
  </tr>
  <tr>
    <td>`max_redemptions`</td>
    <td>A positive integer specifying the number of times the coupon can be redeemed before it’s no longer valid. For example, you might have a 50% off coupon that the first 20 readers of your blog can use.</td>
  </tr>
  <tr>
    <td>`redeem_by`</td>
    <td>Unix timestamp specifying the last time at which the coupon can be redeemed. After the redeem_by date, the coupon can no longer be applied to new customers.</td>
  </tr>
  <tr>
    <td>`metadata`</td>
    <td>A set of key/value pairs that you can attach to a coupon object. It can be useful for storing additional information about the coupon in a structured format. This will be unset if you POST an empty value. This can be unset by updating the value to nil and then saving.</td>
  </tr>
</table>
