### PR TITLE
Disallow deleting a plan if it has any related subscriptions

### DIFF
--- a/app/models/concerns/payola/plan.rb
+++ b/app/models/concerns/payola/plan.rb
@@ -14,7 +14,8 @@ module Payola
 
       before_create :create_stripe_plan, if: -> { Payola.create_stripe_plans }
 
-      has_many :subscriptions, :class_name => "Payola::Subscription"
+      has_many :subscriptions, :class_name => "Payola::Subscription", as: :plan,
+        dependent: :restrict_with_exception
 
       Payola.register_subscribable(self)
     end

--- a/spec/concerns/plan_spec.rb
+++ b/spec/concerns/plan_spec.rb
@@ -28,6 +28,18 @@ module Payola
       expect(subscription_plan.valid?).to be false
     end
 
+    context "with an associated subscription" do
+      let :subscription do
+        create(:subscription, plan: create(:subscription_plan))
+      end
+
+      it "should fail when attempting to destroy it" do
+        expect {
+          subscription.plan.destroy
+        }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      end
+    end
+
     context "with Payola.create_stripe_plans set to true" do
       before { Payola.create_stripe_plans = true }
 


### PR DESCRIPTION
Even if Stripe allows deleting a plan with subscriptions (and it will
keep the subscriptions), for referential integrity purposes in the
relational DB we shouldn't allow it. If you want to allow deleting a
plan then you should implement some variation of soft-deletes. I'm sure
that's what Stripe really does in the background so "deleting a plan"
actually just hides it.