### PR TITLE
Test Payola against Rails versions 4.1, 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 .rspec
 *.sublime-*
 .idea
+vendor/bundle*

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,18 @@
+dependencies:
+  cache_directories:
+    - "vendor/bundle_rails-4.2"
+    - "vendor/bundle_rails-4.1"
+
+  override:
+    - bundle install --path=vendor/bundle_rails-4.2
+    - bundle install --gemfile=gemfiles/rails-4.1.gemfile --path=../vendor/bundle_rails-4.1
+
 database:
   override:
     - cp config/database.yml.ci config/database.yml
     - bundle exec rake db:create db:migrate db:seed --trace
+
+test:
+  override:
+    - bundle exec rake
+    - BUNDLE_GEMFILE=gemfiles/rails-4.1.gemfile bundle exec rake

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
 group :test do
+  gem 'rspec-rails', '~> 3.3.3'
   gem 'simplecov', require: false
   gem 'codeclimate-test-reporter', require: nil
 end
 gem 'rspec_junit_formatter'
 
-gem 'rails', git: 'https://github.com/rails/rails', branch: '4-2-stable'
+gem 'rails', git: 'https://github.com/rails/rails', branch: '4-1-stable'

--- a/payola.gemspec
+++ b/payola.gemspec
@@ -1,9 +1,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
-# Maintain your gem's version:
 require "payola/version"
 
-# Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "payola-payments"
   s.version     = Payola::VERSION
@@ -14,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "One-off and subscription payments for your Rails application"
   s.license     = "LGPL-3.0"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md", "CHANGELOG.md"]
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", ">= 4.1"
@@ -25,9 +23,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency "factory_girl_rails"
   s.add_development_dependency "stripe-ruby-mock", "2.1.0"
   s.add_development_dependency "sucker_punch", "~> 1.2.1"
   s.add_development_dependency "docverter"
-
 end


### PR DESCRIPTION
Specs are running (and passing) against Rails 4.1 and 4.2 on CI environment. This PR lays the groundwork to introduce Rails 5.0 testing+support in a subsequent PR.