### PR TITLE
Fix api_key String spec errors with stripe-ruby-mock 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Payola will be documented in this file.
 - Fix flash message typo 'Successfully'. #228
 - Make tax percentage migration reversible. #242
 - Call `instrument_quantity_changed` from `ChangeSubscriptionQuantity`. #250
+- Fix api_key String spec errors with stripe-ruby-mock 2.3.1. #261
 
 ## v1.4.0 - 2016-01-28
 [Full Changelog](https://github.com/peterkeen/payola/compare/v1.3.2...v1.4.0)

--- a/payola.gemspec
+++ b/payola.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"
-  s.add_development_dependency "stripe-ruby-mock", ">=2.1.0"
+  s.add_development_dependency "stripe-ruby-mock", ">= 2.3.1"
   s.add_development_dependency "sucker_punch", "~> 1.2.1"
   s.add_development_dependency "docverter"
 end


### PR DESCRIPTION
`TypeError: api_key must be a string` errors happen with certain version
combinations of stripe-ruby and stripe-ruby-mock. Certain versions of
stripe-ruby-mock seem to be the trigger (e.g. 2.1.0) used in combination
with more recent stripe-ruby versions (e.g. 1.55.0) that perform the
api_key-String check.