### PR TITLE
Ensure ENV keys are seen as strings

### DIFF
--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -139,6 +139,12 @@ module Payola
     def ==(other)
       to_s == other.to_s
     end
+
+    # This is a nasty hack to counteract Stripe checking if the API key is_a String
+    # See https://github.com/peterkeen/payola/issues/256 for details
+    def is_a?(other)
+      ENV[@key].is_a?(other)
+    end
   end
 
   self.reset!

--- a/spec/models/payola/env_wrapper_spec.rb
+++ b/spec/models/payola/env_wrapper_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+module Payola
+  describe EnvWrapper do
+    describe "delegations" do
+      it "should delgate is_a?" do
+        ENV['whatever'] = 'some value'
+        wrap = EnvWrapper.new('whatever')
+        expect(wrap.is_a?(String)).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stripe started checking types on the API key at some point, which
means our `EnvWrapper` stopped being effective. This patch passes
the `is_a?` call through to the underlying ENV value.

Fixes #256