### PR TITLE
Pass controller into redirect_path

### DIFF
--- a/app/controllers/concerns/payola/async_behavior.rb
+++ b/app/controllers/concerns/payola/async_behavior.rb
@@ -6,7 +6,16 @@ module Payola
       object = object_class.find_by!(guid: params[:guid])
       redirector = object.redirector
 
-      new_path = redirector.respond_to?(:redirect_path) ? redirector.redirect_path(object) : '/'
+      new_path = '/'
+
+      if redirector.respond_to?(:redirect_path)
+        if redirector.method(:redirect_path).arity == 2
+          new_path = redirector.redirect_path(object, self)
+        else
+          new_path = redirector.redirect_path(object)
+        end
+      end
+
       redirect_to new_path
     end
 

--- a/spec/controllers/payola/transactions_controller_spec.rb
+++ b/spec/controllers/payola/transactions_controller_spec.rb
@@ -90,6 +90,18 @@ module Payola
 
         expect(response).to redirect_to '/'
       end
+
+      it "should call redirect_path with two arguments if possible" do
+        sale = create(:sale)
+        sale.update(product_type: 'TwoArgumentProduct')
+        sale.save!
+
+        expect(sale.product.method(:redirect_path).arity).to eq(2)
+
+        get :show, params: { guid: sale.guid }
+
+        expect(response).to redirect_to "/#{sale.id}/Payola::TransactionsController"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,3 +94,9 @@ module Payola
     end
   end
 end
+
+class TwoArgumentProduct < Product
+  def redirect_path(object, controller)
+    "/" + [object.id, controller.class].join("/")
+  end
+end


### PR DESCRIPTION
This passes the current controller into `redirect_path` which allows you to use routes without having to go through crazy contortions.