### PR TITLE
Allow subscription plans with free trials to start without payment info

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -139,8 +139,12 @@ module Payola
       return true if stripe_customer_id.present?
       return true if plan.nil?
       if (plan.amount > 0 )
-        if plan.respond_to?(:trial_period_days) and (plan.trial_period_days.nil? or ( plan.trial_period_days and !(plan.trial_period_days > 0) ))
-          errors.add(:base, 'No Stripe token is present for a paid plan') if stripe_token.nil?
+        if plan.respond_to?(:trial_period_days)
+          if Payola.allow_no_payment_info_for_trial_periods and (plan.trial_period_days.nil? or plan.trial_period_days <= 0)
+            errors.add(:base, 'No Stripe token is present for a paid plan without a trial period') if stripe_token.nil?
+          elsif (plan.trial_period_days.nil? or ( plan.trial_period_days and !(plan.trial_period_days > 0) ))
+            errors.add(:base, 'No Stripe token is present for a paid plan') if stripe_token.nil?
+          end
         end
       end
     end

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -94,6 +94,11 @@ module Payola
         end
       end
 
+      customer_create_params = {
+        source: subscription.stripe_token,
+        email:  subscription.email
+      }
+
       if subscription.plan.amount > 0 and
         not subscription.stripe_token.present?
         if Payola.allow_no_payment_info_for_trial_periods
@@ -101,16 +106,15 @@ module Payola
              not subscription.plan.trial_period_days.present? or
              subscription.plan.trial_period_days <= 0
              raise "A payment method is required for subscription plans without a free trial period"
+          else
+            customer_create_params.delete(:source)
           end
         else
           raise "stripeToken required for new customer with paid subscription"
         end
       end
 
-      customer_create_params = {
-        source: subscription.stripe_token,
-        email:  subscription.email
-      }
+
 
       customer = Stripe::Customer.create(customer_create_params, secret_key)
 

--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -94,8 +94,17 @@ module Payola
         end
       end
 
-      if subscription.plan.amount > 0 and not subscription.stripe_token.present?
-        raise "stripeToken required for new customer with paid subscription"
+      if subscription.plan.amount > 0 and
+        not subscription.stripe_token.present?
+        if Payola.allow_no_payment_info_for_trial_periods
+          if not subscription.plan.respond_to?(:trial_period_days) or
+             not subscription.plan.trial_period_days.present? or
+             subscription.plan.trial_period_days <= 0
+             raise "A payment method is required for subscription plans without a free trial period"
+          end
+        else
+          raise "stripeToken required for new customer with paid subscription"
+        end
       end
 
       customer_create_params = {

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -31,7 +31,8 @@ module Payola
       :additional_charge_attributes,
       :guid_generator,
       :pdf_receipt,
-      :create_stripe_plans
+      :create_stripe_plans,
+      :allow_no_payment_info_for_trial_periods
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?
@@ -92,6 +93,7 @@ module Payola
       self.pdf_receipt = false
       self.guid_generator = lambda { SecureRandom.random_number(1_000_000_000).to_s(32) }
       self.create_stripe_plans = true
+      self.allow_no_payment_info_for_trial_periods = false
     end
 
     def register_sellable(klass)

--- a/spec/models/payola/subscription_spec.rb
+++ b/spec/models/payola/subscription_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 module Payola
   describe Subscription do
 
+    before do
+      Payola.allow_no_payment_info_for_trial_periods = false
+    end
+
     describe "validations" do
       it "should validate" do
         subscription = build(:subscription)
@@ -21,6 +25,20 @@ module Payola
 
       it "should not validate nil stripe_token on paid plan" do
         plan = create(:subscription_plan)
+        subscription = build(:subscription, stripe_token: nil, plan: plan)
+        expect(subscription.valid?).to be false
+      end
+
+      it "should validate for nil stripe_token on paid plan when configured to allow plans with trial periods to allow no payment info" do
+        Payola.allow_no_payment_info_for_trial_periods = true
+        plan = create(:subscription_plan, trial_period_days: 10)
+        subscription = build(:subscription, stripe_token: nil, plan: plan)
+        expect(subscription.valid?).to be true
+      end
+
+      it "should not validate for nil stripe_token on paid plan without trial period when configured to allow plans with trial periods to allow no payment info" do
+        Payola.allow_no_payment_info_for_trial_periods = true
+        plan = create(:subscription_plan, trial_period_days: 0)
         subscription = build(:subscription, stripe_token: nil, plan: plan)
         expect(subscription.valid?).to be false
       end

--- a/spec/payola_spec.rb
+++ b/spec/payola_spec.rb
@@ -63,13 +63,13 @@ module Payola
     describe "with callable" do
       it "should call the callable" do
         foo = nil
-        
+
         Payola.background_worker = lambda do |sale|
           foo = sale
         end
-  
+
         Payola.queue!('blah')
-  
+
         expect(foo).to eq 'blah'
       end
     end
@@ -140,6 +140,13 @@ module Payola
     it "defaults to true" do
       Payola.reset!
       expect(Payola.create_stripe_plans).to be true
+    end
+  end
+
+  describe "#allow_no_payment_info_for_trial_periods" do
+    it "defaults to false" do
+      Payola.reset!
+      expect(Payola.allow_no_payment_info_for_trial_periods).to be false
     end
   end
 end


### PR DESCRIPTION
This allows a user to start a subscription that has a plan with a free trial to be started without any payment info (Stripe Token). We've also extended the test suites to cover this case, and also explicitly test existing functionality around it.

Since this could introduce breaking changes for anyone who's relying on the assumption that a subscription plan with a free trial will fail to be created, this behavior is only enabled if the flag `allow_no_payment_info_for_trial_periods` is set to `true` for the Payola configuration. Even if enabled, the code explicitly does not _not_ allow subscription plans which have no trial period, or a trial period of 0 days, to happen without payment info.

A few minor notes:
1. None of the front-end javascript for creating subscriptions is changed- to do that would require more work that I think would benefit from a discussion about how to name/architect the flags for allowing that.
2. I'd argue it's common practice in SAAS apps now to not ask for credit card info up front when starting a free trial, so it may make sense to transition to this being the default and build in elegant support in the rest of the app in a future major version.
3. We found that supporting free trials without payment info *is* the default (and tested) within the Subscription model, however this behavior is prevented by the method `find_or_create_customer` in the `StartSubscription` service, which raises an exception. Finding/creating a customer seems like an odd place to put the logic for testing whether a lack of payment info should prevent a subscription from being started, but we did not want to refactor this in the case someone out there is relying on this behavior in some way.

We can also add a wiki page explaining how to enable this functionality (and an example code snippet of the Javascript changes you need to make to your front-end, which are fairly straightforward)
