### PR TITLE
Create a Sale with existing Stripe customer without credit card (yet)

### DIFF
--- a/app/services/payola/create_sale.rb
+++ b/app/services/payola/create_sale.rb
@@ -8,7 +8,7 @@ module Payola
       if params[:stripe_customer_id].present?
         customer = Stripe::Customer.retrieve(params[:stripe_customer_id], Payola.secret_key)
         email = customer.email
-        token = customer.default_source
+        token = customer.default_source || params[:stripeToken]
       else
         email = params[:stripeEmail]
         token = params[:stripeToken]


### PR DESCRIPTION
Hey, 
in my app after a User is registered a free subscription is created on Stripe. Then the user can subscribe multiple plans (Payola::Subscripitons) or buy one-time licences (Payola::Sale). He can do them at same time, like a shopping cart, and if I haven't created earlier a Stripe User (getting stripe_customer_id) I have multiple customers on Stripe. 

If I try to buy one Product I have 400 bad request. I've been digging into code. 

`
Started POST "/it/payola/buy/optional/p1" for 127.0.0.1 at 2017-11-21 10:28:24 +0100
Processing by Payola::TransactionsController#create as */*
`

https://github.com/payolapayments/payola/blob/master/app/controllers/payola/transactions_controller.rb#L18 

```
def create
      create_object(Sale, CreateSale, ProcessSale, :product, @product)
end
```

https://github.com/payolapayments/payola/blob/2cbecc0e853504c233e633311e375497b6f2bbf3/app/controllers/concerns/payola/async_behavior.rb#L18

On line 34
`object = object_creator_class.call(create_params)`

https://github.com/payolapayments/payola/blob/c5a5c705621d885fe39aba196c1df524898fe991/app/services/payola/create_sale.rb#L3

I have a stripe_customer_id, so in line 11 customer.default_source is null. It is correct, because my User is registered, but he has not a card yet. But there is a credit card and I have a valid params[:stripeToken]
 
400 Bad Request StripeToken can't be blank

Possible fix for line 11:
`token = customer.default_source || params[:stripeToken]`