### PR TITLE
fix edgecase scenario for users with expired cards that are re-subscr…

### DIFF
--- a/app/services/payola/start_subscription.rb
+++ b/app/services/payola/start_subscription.rb
@@ -75,7 +75,7 @@ module Payola
         customer = Stripe::Customer.retrieve(stripe_customer_id, secret_key)
 
         unless customer.try(:deleted)
-          if customer.default_source.nil? && subscription.stripe_token.present?
+          if subscription.stripe_token.present?
             customer.source = subscription.stripe_token
             customer.save
           end


### PR DESCRIPTION
…ibing

old scenario that caused a bug:
  1. user has an account and a subscription
  2. user's card expired, subscription expires, user no longer has access
  3. user purchases a new subscription - payola is clever and uses the existing
     stripe `customer` record. This existing customer record has an expired card
     attached as the `default_source`
  4. creating a new subscription fails with a "card expired" error :(

SOLUTION: if the subscription has a `stripe_token` attached, let's just use
          it and set it as the new source for the customer, overriding the old one