### PR TITLE
Fix undefined method error on newer stripe gem version

### DIFF
--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -104,6 +104,14 @@ module Payola
       self.amount               = stripe_sub.plan.amount
       self.currency             = stripe_sub.plan.respond_to?(:currency) ? stripe_sub.plan.currency : Payola.default_currency
       self.cancel_at_period_end = stripe_sub.cancel_at_period_end
+      
+      Payola.subscribables.values.each do |plan_class|
+        plan = plan_class.find_by(stripe_id: stripe_sub.plan.id)
+        if plan
+          self.plan = plan
+          break
+        end
+      end
 
       # Support for discounts is added to stripe-ruby-mock in v2.2.0, 84f08eb
       self.coupon               = stripe_sub.discount && stripe_sub.discount.coupon.id if stripe_sub.respond_to?(:discount)

--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -104,14 +104,6 @@ module Payola
       self.amount               = stripe_sub.plan.amount
       self.currency             = stripe_sub.plan.respond_to?(:currency) ? stripe_sub.plan.currency : Payola.default_currency
       self.cancel_at_period_end = stripe_sub.cancel_at_period_end
-      
-      Payola.subscribables.values.each do |plan_class|
-        plan = plan_class.find_by(stripe_id: stripe_sub.plan.id)
-        if plan
-          self.plan = plan
-          break
-        end
-      end
 
       # Support for discounts is added to stripe-ruby-mock in v2.2.0, 84f08eb
       self.coupon               = stripe_sub.discount && stripe_sub.discount.coupon.id if stripe_sub.respond_to?(:discount)

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -145,6 +145,11 @@ module Payola
     def is_a?(other)
       ENV[@key].is_a?(other)
     end
+    
+    # similar to above - fixes an issue with newer stripe gem checking start_with?
+    def start_with?(*args)
+      ENV[@key].start_with?(*args)
+    end
   end
 
   self.reset!


### PR DESCRIPTION
With Stripe gem 3.11.0 there looks to be a new start_with? check against the secret key - this PR adds the necessary method to support that.

Similar to the fix employed for #256 

top of stacktrace:
```ruby
undefined method `start_with?' for #<Payola::EnvWrapper:0x000055d02982d6c0 @key="STRIPE_SECRET_KEY">
…/ruby/gems/2.5.0/gems/stripe-3.11.0/lib/stripe/util.rb:  294:in `request_id_dashboard_url'
…s/2.5.0/gems/stripe-3.11.0/lib/stripe/stripe_client.rb:  468:in `log_response'
…s/2.5.0/gems/stripe-3.11.0/lib/stripe/stripe_client.rb:  201:in `execute_request_with_rescues'
…s/2.5.0/gems/stripe-3.11.0/lib/stripe/stripe_client.rb:  152:in `execute_request'
```